### PR TITLE
Install shellwhat_ext from datacamp, lock version

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -8,7 +8,7 @@ COURSE_ID=course_5355
 ARCHIVE=setup.zip
 PYTHON=python3
 PIP=pip3
-SHELLWHAT_EXT=git+https://github.com/gvwilson/shellwhat_ext.git@v0.2.0
+SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@v0.2.0
 
 # Report start.
 echo ''

--- a/requirements.sh
+++ b/requirements.sh
@@ -8,7 +8,7 @@ COURSE_ID=course_5355
 ARCHIVE=setup.zip
 PYTHON=python3
 PIP=pip3
-SHELLWHAT_EXT=git+https://github.com/gvwilson/shellwhat_ext.git
+SHELLWHAT_EXT=git+https://github.com/gvwilson/shellwhat_ext.git@v0.2.0
 
 # Report start.
 echo ''
@@ -29,7 +29,7 @@ apt-get -y install unzip
 
 # Python package installation.
 ${PIP} install gitpython
-${PIP} install ${SHELLWHAT_EXT}
+${PIP} install ${SHELLWHAT_EXT} --no-deps
 ${PYTHON} -c "import sys; print('sys.version:', sys.version)"
 ${PYTHON} -c "import git; print('gitpython version:', git.__version__)"
 ${PYTHON} -c "import shellwhat_ext; print('shellwhat_ext version:', shellwhat_ext.__version__)"


### PR DESCRIPTION
The shellwhat_ext version being installed with the one that is behind your personal GitHub account.
For handling updates better in the future, it is now locked on a version of the datacamp/shellwhat_ext repo. 