### PR TITLE
Rewrite all SCTs according to new version of shellwhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 - Docs: https://authoring.datacamp.com
 
 Version control is the beating heart of every productive programmer's workflow.
-It allow people to keep track of what they've done,
+It allows people to keep track of what they've done,
 and to share what they're currently doing with colleagues.
-This course is an introduction to version control with Git
-for data scientists
+This course is an introduction to version control with Git for data scientists
 who can already use the Unix shell to run simple commands and edit text files.
 
 ## Step 0: Learner Profiles
@@ -235,17 +234,3 @@ and show you how it can help you get more done in less time and with less pain.
 [profile-site]: https://github.com/datacamp/learner-profiles
 [profile-thanh]: https://github.com/datacamp/learner-profiles#thanh
 [profile-yngve]: https://github.com/datacamp/learner-profiles#yngve
-
-###  DataCamp Referral Program For B2B Customers
-
-:moneybag: :dollar:
-
-DataCamp is offering a special promotion where instructors can earn a referral fee for introducing DataCamp to new prospects.
-
-* You receive a 15% revenue share on the initial contract we sign with your referral (For example if you refer a financial service company that buys $30,000 worth of DataCamp subscriptions, we would pay you $4,500)
-* **Referrals are very easy to make and all you need to do is fill out [this referral form](https://docs.google.com/forms/d/e/1FAIpQLSeb9tGdH3akd2VA1uQpdftc218K_tEKhIUxAogYZoiH7zdPbg/viewform)**
-* This referral opportunity is in addition to the royalty payments you already receive
-* The primary target is businesses but we also sell to government agencies and graduate programs at universities
-
-More info: robert@datacamp.com
-

--- a/chapter1.md
+++ b/chapter1.md
@@ -720,7 +720,7 @@ repl.run_command('cd dental')
 *** =sct
 ```{python}
 err = 'Incorrect: please re-run the command and use `git log`.'
-Ex().has_chosen(1, ['Correct', err, err, err])
+Ex().has_chosen(1, ["Correct! `git log` is a convenient way to remind yourself what you've been working on.", err, err, err])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->

--- a/chapter1.md
+++ b/chapter1.md
@@ -41,13 +41,12 @@ Which of the following does Git do?
 
 Git is a very versatile tool.
 
-*** =feedbacks
+*** =feedback
 - Yes, but that's not all.
 - Yes, but that's not all.
 - Yes, but that's not all.
 - Correct.
 
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:1dac2b0a28
 ## Where does Git store information?
@@ -89,10 +88,8 @@ e1 = 'No: every repository stores its own history.'
 c2 = 'Yes: all of the information about a repository is stored under its root directory.'
 e3 = 'No: all of the information about a repository is stored under its root directory.'
 e4 = 'No: one of the answers above is correct.'
-Ex() >> test_mc(2, [e1, c2, e3, e4])
+Ex().has_chosen(2, [e1, c2, e3, e4])
 ```
-
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:bc52cf1174
 ## How can I check the state of a repository?
@@ -134,13 +131,11 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(2, ['No, that file has not changed.', \
+Ex().has_chosen(2, ['No, that file has not changed.', \
                     'Correct!', \
                     'No, one file has changed.', \
                     'No, only one file has changed.'])
 ```
-
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:BulletConsoleExercise key:0dd628a298
 ## How can I tell what I have changed?
@@ -195,12 +190,15 @@ git diff
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+diff\s*',
-                           fixed=False,
-                           msg='Use `git diff`.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(),
+        has_code(r'\s*git\s+diff\s*', incorrect_msg='Use `git diff` without extra arguments.')
+    )
+)
 ```
 
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:MultipleChoiceExercise lang:shell xp:50 skills:1 key:eef645517f
 ## What is in a diff?
@@ -270,7 +268,7 @@ repl.run_command('cd dental')
 err_some = 'No, the commit changed some of the lines.'
 correct = 'Yes, the commit changed one line.'
 err_fewer = 'No, the commit did not change that many lines.'
-Ex() >> test_mc(2, [err_some, correct, err_fewer, err_fewer])
+Ex().has_chosen(2, [err_some, correct, err_fewer, err_fewer])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -323,9 +321,12 @@ git add report.txt
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add\s+report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git add` and a filename.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep report.txt',
+                    output = 'report.txt',
+                    incorrect_msg = "It seems that `report.txt` was not added to the staging area. Have you used `git add report.txt`?")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -339,7 +340,7 @@ Use another Git command to check the repository's status.
 
 *** =hint2
 
-Use Git to check the *status* of the repository.
+Use `git status` to check the *status* of the repository.
 
 *** =sample_code2
 ```{shell}
@@ -352,9 +353,13 @@ git status
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status\s*',
-                           fixed=False,
-                           msg='Use `git status`.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
+        has_code(r'\s*git\s+status\s*')
+    )
+)
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -388,10 +393,7 @@ repl.run_command('git add data/northern.csv')
 
 *** =instructions1
 
-You have been put in the `dental` repository,
-and `data/northern.csv` has been added to the staging area.
-Use `git diff` with `-r` and an argument to see how files differ from
-the last saved revision.
+You have been put in the `dental` repository, where `data/northern.csv` has been added to the staging area. Use `git diff` with `-r` and an argument to see how files differ from the last saved revision.
 
 *** =hint1
 
@@ -408,9 +410,13 @@ git diff -r HEAD
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+diff\s+-r\s+HEAD.*',
-                           fixed=False,
-                           msg='Use `git diff -r HEAD (with or without a directory name)`.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = 'Use `git diff -r HEAD` (with or without a directory name)'),
+        has_code(r'\s*git\s+diff\s+-r\s+HEAD.*')
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -438,9 +444,13 @@ git diff -r HEAD data/northern.csv
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+diff\s+-r\s+HEAD\s+data/northern\.csv\s*',
-                           fixed=False,
-                           msg='Use `git diff -r HEAD` and a filename.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(strict = True, incorrect_msg = 'Use `git diff -r HEAD data/northern.csv` to view the changes of the staged file only.'),
+        has_code(r'\s*git\s+diff\s+-r\s+HEAD\s+data/northern\.csv\s*')
+    )
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -450,7 +460,7 @@ Ex() >> test_student_typed(r'\s*git\s+diff\s+-r\s+HEAD\s+data/northern\.csv\s*',
 
 *** =instructions3
 
-Use one Git command to add the other changed file to the staging area.
+`data/eastern.csv` hasn't been added to the staging area yet. Use a Git command to do this now.
 
 *** =hint3
 
@@ -467,9 +477,14 @@ git add data/eastern.csv
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add\s+(data/eastern\.csv|\.)\s*',
-                           fixed=False,
-                           msg='Use `git add *filename*`.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep data/eastern.csv',
+                    output = 'data/eastern.csv',
+                    strict = True,
+                    incorrect_msg = "It seems that `data/eastern.csv` wasn't added to the staging area. Have you used `git add data/eastern.csv`?")
+)
+Ex().success_msg("Great! Before we dive into actually committing the changes you have added to the staging area, let's quickly recap how to work with text editors in the terminal.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -512,16 +527,24 @@ then Ctrl-X and Enter to exit the editor.
 
 *** =solution
 ```{shell}
-# Run this command *without* 'echo' at the front:
-echo nano names.txt
+# This solution uses another command
+# because our automated tests can't edit files interactively.
+echo -e "Lovelace\nHopper\nJohnson\nWilson" > names.txt
 ```
 
 *** =sct
 ```{python}
-from shellwhat_ext import test_compare_file_to_file
-Ex() >> test_student_typed(r'.*nano\s+names.txt.*',
-                           fixed=False,
-                           msg='Use `nano names.txt`.')
+patt = "Have you included the line `%s` in the `names.txt` file? Use `nano names.txt` again to update your file. Use Ctrl-O to save and Ctrl-X to exit."
+Ex().multi(
+    has_cwd('/home/repl'),
+    check_file('/home/repl/names.txt').multi(
+        has_code('Lovelace', incorrect_msg=patt%'Lovelace'),
+        has_code('Hopper', incorrect_msg=patt%'Hopper'),
+        has_code('Johnson', incorrect_msg=patt%'Johnson'),
+        has_code('Wilson', incorrect_msg=patt%'Wilson')
+    )
+)
+Ex().success_msg("Well done! Off to the next one!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -573,7 +596,7 @@ repl.run_command('git add report.txt')
 
 You have been put in the `dental` repository,
 and `report.txt` has been added to the staging area.
-Use one Git command to check the status of the repository.
+Use a Git command to check the status of the repository.
 
 *** =hint1
 
@@ -590,9 +613,13 @@ git status
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status\s*',
-                           fixed=False,
-                           msg='Remember, you want to check the *status* of the repository.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
+        has_code(r'\s*git\s+status\s*')
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -619,9 +646,14 @@ git commit -m "Adding a reference."
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit\s+-m\s+("[^"]+"|\'[^\']+\')\s*',
-                           fixed=False,
-                           msg='Use `git commit` with `-m "message"`.')
+msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
+                    output = 'report.txt',
+                    incorrect_msg=msg)
+)
+Ex().success_msg("You committed the file!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -678,7 +710,7 @@ repl.run_command('cd dental')
 *** =sct
 ```{python}
 err = 'Incorrect: please re-run the command and use `git log`.'
-Ex() >> test_mc(1, ['Correct', err, err, err])
+Ex().has_chosen(1, ['Correct', err, err, err])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -719,7 +751,7 @@ repl.run_command('cd dental')
 *** =sct
 ```{python}
 err = 'Incorrect: please use `git log data/southern.csv` and count the number of log entries.'
-Ex() >> test_mc(3, [err, err, 'Correct!', err])
+Ex().has_chosen(3, [err, err, 'Correct!', err])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -772,6 +804,8 @@ You have been put in the `dental` repository,
 and `report.txt` has been added to the staging area.
 The changes to `report.txt` have already been staged.
 Use `git commit` *without* `-m` to commit the changes.
+The Nano editor will open up. Write a meaningful message
+and use Ctrl+O and Ctrl+X to save and leave the editor.
 
 *** =hint1
 
@@ -784,13 +818,18 @@ Run `git commit` without any arguments.
 
 *** =solution1
 ```{shell}
-# You should run 'git commit' *without* -m:
+# This solution uses another command
+# because our automated tests can't edit files interactively.
 git commit -m "Adding a reference."
 ```
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit\s*',
-                           fixed=False,
-                           msg='Use `git add` without `-m`.')
+msg="It seems that the staged changes to `report.txt` weren't committed. Use `git commit` to interactively write a commit message. If you're struggling, you can always use the `-m \"any message\"` flag to avoid the interaction."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
+                    output = 'report.txt', incorrect_msg=msg)
+)
+Ex().success_msg("Neat! This concludes chapter 1, where you learned about `git diff`, `git status`, `git add` and `git commit`. Quite something! Rush over to chapter 2 to continue your Git adventure!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -194,7 +194,7 @@ Ex().multi(
     has_cwd('/home/repl/dental'),
     check_or(
         has_expr_output(),
-        has_code(r'\s*git\s+diff\s*', incorrect_msg='Use `git diff` without extra arguments.')
+        has_code(r'\s*git\s+diff\s*', incorrect_msg='Use `git` followed by `diff` without extra arguments.')
     )
 )
 ```
@@ -266,7 +266,7 @@ repl.run_command('cd dental')
 *** =sct
 ```{python}
 err_some = 'No, the commit changed some of the lines.'
-correct = 'Yes, the commit changed one line.'
+correct = 'Yes, the commit added one line.'
 err_fewer = 'No, the commit did not change that many lines.'
 Ex().has_chosen(2, [err_some, correct, err_fewer, err_fewer])
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -538,10 +538,10 @@ patt = "Have you included the line `%s` in the `names.txt` file? Use `nano names
 Ex().multi(
     has_cwd('/home/repl'),
     check_file('/home/repl/names.txt').multi(
-        has_code('Lovelace', incorrect_msg=patt%'Lovelace'),
-        has_code('Hopper', incorrect_msg=patt%'Hopper'),
-        has_code('Johnson', incorrect_msg=patt%'Johnson'),
-        has_code('Wilson', incorrect_msg=patt%'Wilson')
+        has_code(r'Lovelace', incorrect_msg=patt%'Lovelace'),
+        has_code(r'Hopper', incorrect_msg=patt%'Hopper'),
+        has_code(r'Johnson', incorrect_msg=patt%'Johnson'),
+        has_code(r'Wilson', incorrect_msg=patt%'Wilson')
     )
 )
 Ex().success_msg("Well done! Off to the next one!")

--- a/chapter1.md
+++ b/chapter1.md
@@ -324,9 +324,9 @@ git add report.txt
 Ex().multi(
 has_cwd('/home/repl/dental'),
   has_expr_output(
-    strict=True, 
     expr='git diff --name-only --staged | grep report.txt',
     output = 'report.txt',
+    strict=True, 
     incorrect_msg = "It seems that `report.txt` was not added to the staging area. Have you used `git add report.txt`?"
   )
 )
@@ -575,6 +575,12 @@ to enter a single-line message like this:
 git commit -m "Program appears to have become self-aware."
 ```
 
+If you accidentally mistype a commit message, you can change it using the `--amend` flag.
+
+```
+git commit --amend - m "new message"
+```
+
 *** =pre_exercise_code
 ```{python}
 append = '''
@@ -648,20 +654,24 @@ git commit -m "Adding a reference."
 *** =sct2
 ```{python}
 not_committed_msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference\"`?"
-bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend - m "new message"`.'
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
 Ex().multi(
     has_cwd('/home/repl/dental'),
     check_or(
-        has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
-                    output = 'report.txt',
-                    strict=True,
-                    incorrect_msg=not_committed_msg),
+        has_expr_output(
+            expr='git diff HEAD~ --name-only | grep report.txt',
+            output = 'report.txt',
+            strict=True,
+            incorrect_msg=not_committed_msg
+        ),
         has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
     ),
-    has_expr_output(expr='git log -1 | grep  --only-matching "Adding a reference"',
-                    output = 'Adding a reference',
-                    strict=True,
-                    incorrect_msg=bad_message_msg)
+    has_expr_output(
+        expr='git log -1 | grep --only-matching "Adding a reference"',
+        output = 'Adding a reference',
+        strict=True,
+        incorrect_msg=bad_message_msg
+    )
 )
 Ex().success_msg("You committed the file!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -616,9 +616,9 @@ git status
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
-        has_code(r'\s*git\s+status\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = "Have a look at the status of your repository with `git status`.")
     )
 )
 ```
@@ -647,12 +647,21 @@ git commit -m "Adding a reference."
 
 *** =sct2
 ```{python}
-msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference\"`?"
+not_committed_msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference\"`?"
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend - m "new message"`.'
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
+    check_or(
+        has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
                     output = 'report.txt',
-                    incorrect_msg=msg)
+                    strict=True,
+                    incorrect_msg=not_committed_msg),
+        has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
+    ),
+    has_expr_output(expr='git log -1 | grep  --only-matching "Adding a reference"',
+                    output = 'Adding a reference',
+                    strict=True,
+                    incorrect_msg=bad_message_msg)
 )
 Ex().success_msg("You committed the file!")
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -322,10 +322,13 @@ git add report.txt
 *** =sct1
 ```{python}
 Ex().multi(
-    has_cwd('/home/repl/dental'),
-    has_expr_output(expr='git diff --name-only --staged | grep report.txt',
-                    output = 'report.txt',
-                    incorrect_msg = "It seems that `report.txt` was not added to the staging area. Have you used `git add report.txt`?")
+has_cwd('/home/repl/dental'),
+  has_expr_output(
+    strict=True, 
+    expr='git diff --name-only --staged | grep report.txt',
+    output = 'report.txt',
+    incorrect_msg = "It seems that `report.txt` was not added to the staging area. Have you used `git add report.txt`?"
+  )
 )
 ```
 
@@ -355,9 +358,9 @@ git status
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
-        has_code(r'\s*git\s+status\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = "Have a look at the status of your repository with `git status`.")
     )
 )
 ```
@@ -367,12 +370,10 @@ Ex().multi(
 --- type:BulletConsoleExercise key:f208f45d7d
 ## How can I tell what's going to be committed?
 
-To compare a file's current state to the changes in the staging area,
-you can use `git diff -r HEAD path/to/file`.
-The `-r` flag means "compare to a particular revision",
-`HEAD` is a shortcut meaning "the most recent commit",
-and the path to the file is the relative to where you are
-(for example, the path from the root directory of the repository).
+To compare the state of your files with those in the staging area, you can use `git diff -r HEAD`. The `-r` flag means "compare to a particular revision", and `HEAD` is a shortcut meaning "the most recent commit".
+
+You can restrict the results to a single file or directory using `git diff -r HEAD path/to/file`, where the path to the file is relative to where you are (for example, the path from the root directory of the repository).
+
 We will explore other uses of `-r` and `HEAD` in the next chapter.
 
 *** =pre_exercise_code
@@ -412,9 +413,9 @@ git diff -r HEAD
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = 'Use `git diff -r HEAD` (with or without a directory name)'),
-        has_code(r'\s*git\s+diff\s+-r\s+HEAD.*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+diff\s+-r\s+HEAD.*', incorrect_msg = 'Use `git diff` with the `-r` flag and `HEAD` (with or without a directory name).')
     )
 )
 ```
@@ -446,9 +447,9 @@ git diff -r HEAD data/northern.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(strict = True, incorrect_msg = 'Use `git diff -r HEAD data/northern.csv` to view the changes of the staged file only.'),
-        has_code(r'\s*git\s+diff\s+-r\s+HEAD\s+data/northern\.csv\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+diff\s+-r\s+HEAD.*', incorrect_msg = 'Use `git diff` with the `-r` flag, `HEAD`, and `data/northern.csv` to view the changes of the staged file only.')
     )
 )
 ```

--- a/chapter1.md
+++ b/chapter1.md
@@ -653,7 +653,7 @@ git commit -m "Adding a reference."
 
 *** =sct2
 ```{python}
-not_committed_msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference\"`?"
+not_committed_msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Adding a reference.\"`?"
 bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
 Ex().multi(
     has_cwd('/home/repl/dental'),

--- a/chapter1.md
+++ b/chapter1.md
@@ -168,7 +168,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: e9c198755a
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -299,7 +299,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: a34bf017f0
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -335,7 +335,7 @@ has_cwd('/home/repl/dental'),
 *** =type2: ConsoleExercise
 *** =key2: 961661800c
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 
@@ -390,7 +390,7 @@ repl.run_command('git add data/northern.csv')
 *** =type1: ConsoleExercise
 *** =key1: 77c975a5c8
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -423,7 +423,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 5a866b3ef0
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -457,7 +457,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 538a9c35d4
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 
@@ -597,7 +597,7 @@ repl.run_command('git add report.txt')
 *** =type1: ConsoleExercise
 *** =key1: 17e219ea22
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -632,7 +632,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: a5ce3bebb8
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 
@@ -816,7 +816,7 @@ repl.run_command('git add report.txt')
 *** =type1: ConsoleExercise
 *** =key1: 2f3aa2a066
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 

--- a/chapter2.md
+++ b/chapter2.md
@@ -704,8 +704,8 @@ Ex().check_correct(
                     incorrect_msg="Have you used `git config --global user.email rep.loop@datacamp.com` to properly configure the email address globally?"),
     multi(
         has_code(r'git\s+config', incorrect_msg="Your command should start with `git config`."),
-        has_code(r'--global', incorrect_msg="You should use the flag `--global`."),
-        has_code(r'user\.email', incorrect_msg="Use `user.email` to tell `git config` you're about to set the email address."),
+        has_code('--global', incorrect_msg="You should use the flag `--global`."),
+        has_code('user.email', incorrect_msg="Use `user.email` to tell `git config` you're about to set the email address."),
         has_code('rep.loop@datacamp.com', fixed=True, incorrect_msg="Make sure to set `user.email` to `rep.loop@datacamp.com`. Beware of typos!")
     )
 )

--- a/chapter2.md
+++ b/chapter2.md
@@ -216,11 +216,14 @@ the first three lines of output from `git annotate report.txt` look something li
 5e6f92b6        (  Rep Loop     2017-09-20 13:42:26 +0000       3)TODO: write executive summary.
 ```
 
-The first column is the hash of the most recent commit to change that line.
-The other columns show who made the change,
-the date and time it was made,
-the line number,
-and the line itself.
+
+Each line contains five things, with two to four in parentheses.
+
+1. The first eight digits of the hash, `04307054`.
+2. The author, `Rep Loop`.
+3. The time of the commit, `2017-09-20 13:42:26 +0000`.
+4. The line number, `1`.
+5. The contents of the line, `# Seasonal Dental Surgeries (2017) 2017-18`.
 
 <hr>
 
@@ -231,9 +234,9 @@ How many different sets of changes have been made to this file
 
 *** =instructions
 - 1.
-- 2.
 - 3.
 - 4.
+- 7.
 
 *** =hint
 
@@ -248,10 +251,11 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-e_more = 'No, there have been more changes than that.'
-correct = 'Correct!'
-e_fewer = 'No, there have been fewer changes than that.'
-Ex().has_chosen(3, [e_more, e_more, correct, e_fewer])
+err1 = 'No, there have been more changes than that.'
+correct = "Correct! `git annotate` let's you see who modified a file and when."
+err3 = 'No, count the number of commit hashes, not the number of non-empty lines.'
+err4 = 'No, count the number of commit hashes, not the total number of lines.'
+Ex().has_chosen(2, [err1, correct, err3, err4])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->

--- a/chapter2.md
+++ b/chapter2.md
@@ -7,29 +7,17 @@ description : >-
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:6d7237913f
 ## How does Git store information?
 
-In order to make common operations fast and minimize storage space,
-Git uses a multi-level structure to store data.
-In simplified form,
-this has three key parts:
+You may wonder what information is stored by each commit that you make. Git uses a three-level structure for this.
 
-1. Every unique version of every file.
-   (Git calls these **blobs** because they can contain data of any kind.)
-2. **tree** that tracks the names and locations of a set of files.
-3. A **commit** that records the author, log message, and other properties
-   of a particular commit.
+1. A **commit** contains metadata such as the author, the commit message, and the time the commit happened. In the diagram below, commits are in the first column. The most recent commit is at the bottom (`feed0098`), and vertical arrows point up towards the previous ("parent") commits.
+2. Each commit also has a **tree**, which tracks the names and locations in the repository when that commit happened. These are shown in the second column. In the oldest (top) commit, there were two files tracked by the repository.
+3. For each of the files listed in the tree, there is a **blob**. This contains a compressed snapshot of the contents of the file when the commit happened. (Blob is short for *binary large object*, which is a SQL database term for "may contain data of any kind".) In the middle commit, `report.md` and `draft.md` were changed, so the blobs are shown next to that commit. `data/northern.csv` didn't change in that commit, so the tree links to the blob from the previous commit. Reusing blobs between commits help make common operations fast and minimizes storage space.
 
 <img src="https://s3.amazonaws.com/assets.datacamp.com/production/course_5355/datasets/commit-tree-blob.png" alt="Commit-Tree-Blob Structure" />
 
-As the diagram shows,
-each blob is stored only once,
-and blobs are (frequently) shared between trees.
-While it may seem redundant to have both trees and commits,
-a later part of this lesson will show why the two have to be distinct.
-
 <hr>
 
-Looking at the diagram,
-which files changed in the last (bottom-most) commit to this repository?
+Looking at the diagram, which files changed in the most recent commit to this repository?
 
 *** =possible_answers
 - [`data/northern.csv`]
@@ -38,7 +26,7 @@ which files changed in the last (bottom-most) commit to this repository?
 
 *** =hint
 
-Look in the right-most column to see which file is new.
+Look in the bottom row, right-most column to see which file was changed.
 
 *** =feedback
 - Correct!

--- a/chapter2.md
+++ b/chapter2.md
@@ -640,9 +640,9 @@ How many local configuration values are set in for this repository?
 
 *** =instructions
 - None.
-- 1.
+- 3.
 - 4.
-- 12.
+- 7.
 
 *** =hint
 
@@ -657,9 +657,9 @@ repl.run_command('cd dental')
 *** =sct
 ```{python}
 Ex().has_chosen(3, ['No, some configuration values are set.',
-                    'No, more configuration values are set than that.',
-                    'Correct!',
-                    'No, fewer configuration values are set than that.'])
+                    'No, there are 3 global settings, but how many local settings are there?',
+                    'Correct! Config settings are useful for storing your name and email address (to identify you in commit logs), choosing your favorite text editor and diff view tools, and customizing things just how you like them.',
+                    'No, there are 7 settings in total, but how many local settings are there?'])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->

--- a/chapter2.md
+++ b/chapter2.md
@@ -40,7 +40,7 @@ which files changed in the last (bottom-most) commit to this repository?
 
 Look in the right-most column to see which file is new.
 
-*** =feedbacks
+*** =feedback
 - Correct!
 - No: that is part of the most recent commit, but wasn't changed in it.
 - No: that file is no longer present in the tree.
@@ -88,7 +88,7 @@ Remember that you can use 'q' to quit the pager.
 *** =sct
 ```{python}
 err = "No, that is not the most recent hash."
-Ex() >> test_mc(4, [err, err, err, "Correct!"])
+Ex().has_chosen(4, [err, err, err, "Correct!"])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -125,13 +125,14 @@ while lines that it added are prefixed with `+`.
 <hr>
 
 You have been put in the `dental` directory.
-(We will now stop reminding you of this...)
 Use `git log` to see the hashes of recent commits,
 and then `git show` with the first few digits of a hash
 to look at the most recent commit.
 How many files did it change?
 
-As before, press `q` to return from the log output to the command prompt.
+Reminder:
+press the space bar to page down through `git log`'s output
+and `q` to quit the paged display.
 
 *** =instructions
 - None.
@@ -155,7 +156,7 @@ repl.run_command('cd dental')
 e_more = 'No, there have been more changes than that.'
 correct = 'Correct!'
 e_fewer = 'No, there have been fewer changes than that.'
-Ex() >> test_mc(2, [e_more, correct, e_fewer, e_fewer])
+Ex().has_chosen(2, [e_more, correct, e_fewer, e_fewer])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -202,7 +203,7 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(2, ['No, the commit `HEAD~1` did not change that file.',
+Ex().has_chosen(2, ['No, the commit `HEAD~1` did not change that file.',
                     'Correct.',
                     'No, the commit `HEAD~1` only changed one file.',
                     'No, the commit `HEAD~1` did change a file.'])
@@ -260,7 +261,7 @@ repl.run_command('cd dental')
 e_more = 'No, there have been more changes than that.'
 correct = 'Correct!'
 e_fewer = 'No, there have been fewer changes than that.'
-Ex() >> test_mc(3, [e_more, e_more, correct, e_fewer])
+Ex().has_chosen(3, [e_more, e_more, correct, e_fewer])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -308,7 +309,7 @@ err_more = 'Yes, but another file was changed as well.'
 err_not = 'No, that file did not change.'
 correct = 'Correct!'
 err_half = 'No, one of those files did not change.'
-Ex() >> test_mc(4, [err_more, err_more, err_not, correct, err_half])
+Ex().has_chosen(4, [err_more, err_more, err_not, correct, err_half])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -357,9 +358,13 @@ git status
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status\s*',
-                           fixed=False,
-                           msg='Remember, you want to check the *status* of the repository.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
+        has_code(r'\s*git\s+status\s*')
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -386,9 +391,12 @@ git add sources.txt
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add\s+(\.|sources\.txt)\s*',
-                           fixed=False,
-                           msg='You can add files one by one or use a directory to add them all.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep sources.txt',
+                    output = 'sources.txt',
+                    incorrect_msg = "It seems that `sources.txt` was not added to the staging area. Have you used `git add sources.txt`?")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -416,9 +424,14 @@ git commit -m "Starting to track data sources."
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit\s+-m\s+"[^"]+"\s*',
-                           fixed=False,
-                           msg='Remember, you want to *commit* files.')
+msg = "It seems that the changes to `sources.txt` you staged in the previous instruction weren't committed. Have you used `git commit` with `-m \"message\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep sources.txt',
+                    output = 'sources.txt',
+                    incorrect_msg=msg)
+)
+Ex().success_msg("That's how it's done!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -461,7 +474,7 @@ backup
 
 To match a set of files, a `.gitignore` entry must contain a wildcard character such as `*`.
 
-*** =feedbacks
+*** =feedback
 - Correct: `pdf` does not contain any wildcards, so it only matches files called `pdf`.
 - This file *is* matched because the pattern `*.pyc` matches files in sub-directories.
 - This file *is* matched because `backup` is a directory, so all files in it are ignored.
@@ -500,7 +513,7 @@ repl.run_command('cd dental')
 *** =instructions1
 
 You are in the `dental` repository.
-Use `ls` to see what files are present.
+Use `git status` to see the status of your repo.
 
 *** =hint1
 
@@ -512,14 +525,18 @@ Run the command as shown.
 
 *** =solution1
 ```{shell}
-ls
+git status
 ```
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*ls\s*',
-                           fixed=False,
-                           msg='Use `ls` without arguments.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
+        has_code(r'\s*git\s+status\s*')
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -529,7 +546,8 @@ Ex() >> test_student_typed(r'\s*ls\s*',
 
 *** =instructions2
 
-Use a single Git command to remove unwanted files.
+`backup.log` appears to be an untracked file and it's one we don't need. Let's get rid of it.
+Use `git clean` with the appropriate flag to remove unwanted files.
 
 *** =hint2
 
@@ -546,9 +564,11 @@ git clean -f
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+clean\s+-f\s*',
-                           fixed=False,
-                           msg='Use `git clean` with the right flag(s).')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='ls | wc -l', output='4',
+                    incorrect_msg="Have you used `git clean -f` to get rid of the unwanted file that wasn't being tracked? After running it, `ls | wc -l` should give 4, but it didn't.")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -558,7 +578,7 @@ Ex() >> test_student_typed(r'\s*git\s+clean\s+-f\s*',
 
 *** =instructions3
 
-Use `ls` again to see what effects your Git command has had.
+List the files in your directory. `backup.log` should no longer be there!
 
 *** =hint3
 
@@ -575,9 +595,14 @@ ls
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*ls\s*',
-                           fixed=False,
-                           msg='Use `ls` without arguments.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Use `ls` to list the files in `dental`, your current working directory."),
+        has_code(r'\s*ls\s*')
+    )
+)
+Ex().success_msg("A job well done! Keeping your repository clean is crucial to keep oversight.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -621,7 +646,7 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(3, ['No, some configuration values are set.',
+Ex().has_chosen(3, ['No, some configuration values are set.',
                     'No, more configuration values are set than that.',
                     'Correct!',
                     'No, fewer configuration values are set than that.'])
@@ -652,7 +677,7 @@ The keys that identify your name and email address are `user.name` and `user.ema
 
 *** =instructions
 
-Change the email address configured for the current user for *all* projects
+Change the email address (`user.email`) configured for the current user for *all* projects
 to `rep.loop@datacamp.com`.
 
 *** =solution
@@ -662,7 +687,17 @@ git config --global user.email rep.loop@datacamp.com
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+config\s+--global\s+user\.email\s+["\']?rep\.loop@datacamp.com["\']?\s*',
-                           fixed=False,
-                           msg='Use `git config --global` with the `user.email` property and the email address.')
+patt='You should use `%s` in your command.'
+Ex().check_correct(
+    has_expr_output(expr='git config --global user.email',
+                    output='rep.loop@datacamp.com',
+                    incorrect_msg="Have you used `git config --global user.email rep.loop@datacamp.com` to properly configure the email address globally?"),
+    multi(
+        has_code(r'git\s+config', incorrect_msg="Your command should start with `git config`."),
+        has_code(r'--global', incorrect_msg="You should use the flag `--global`."),
+        has_code(r'user\.email', incorrect_msg="Use `user.email` to tell `git config` you're about to set the email address."),
+        has_code('rep.loop@datacamp.com', fixed=True, incorrect_msg="Make sure to set `user.email` to `rep.loop@datacamp.com`. Beware of typos!")
+    )
+)
+Ex().success_msg("Well configured! Head over to chapter 3 to continue learning about Git!")
 ```

--- a/chapter2.md
+++ b/chapter2.md
@@ -315,9 +315,11 @@ Git does not track files by default.
 Instead,
 it waits until you have used `git add` at least once
 before it starts paying attention to a file.
-To remind you to do this,
-`git status` will always tell you about files that are in your repository
-but aren't (yet) being tracked.
+
+In the diagram you saw at the start of the chapter, the untracked files won't have a blob, and won't be listed in a tree.
+
+
+The untracked files won't benefit from version control, so to make sure you don't miss anything, `git status` will always tell you about files that are in your repository but aren't (yet) being tracked.
 
 *** =pre_exercise_code
 ```{python}
@@ -354,9 +356,9 @@ git status
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
-        has_code(r'\s*git\s+status\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = "Have a look at the status of your repository with `git status`.")
     )
 )
 ```
@@ -372,7 +374,7 @@ Use `git add` to add the new file to the staging area.
 
 *** =hint2
 
-Remember: `git add` shouldb e followed by either a filename or a directory name (such as '.' for the current working directory).
+Remember: `git add` should be followed by either a filename or a directory name (such as '.' for the current working directory).
 
 *** =sample_code2
 ```{shell}
@@ -389,6 +391,7 @@ Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output(expr='git diff --name-only --staged | grep sources.txt',
                     output = 'sources.txt',
+                    strict=True, 
                     incorrect_msg = "It seems that `sources.txt` was not added to the staging area. Have you used `git add sources.txt`?")
 )
 ```
@@ -418,12 +421,25 @@ git commit -m "Starting to track data sources."
 
 *** =sct3
 ```{python}
-msg = "It seems that the changes to `sources.txt` you staged in the previous instruction weren't committed. Have you used `git commit` with `-m \"message\"`?"
+not_committed_msg = "It seems that the staged changes to `sources.txt` weren't committed. Have you used `git commit` with `-m \"Starting to track data sources.\"`?"
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(expr='git diff HEAD~ --name-only | grep sources.txt',
-                    output = 'sources.txt',
-                    incorrect_msg=msg)
+    check_or(
+        has_expr_output(
+            expr='git diff HEAD~ --name-only | grep sources.txt',
+            output = 'sources.txt',
+            strict=True,
+            incorrect_msg=not_committed_msg
+        ),
+        has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
+    ),
+    has_expr_output(
+        expr='git log -1 | grep --only-matching "Starting to track data sources"',
+        output = 'Starting to track data sources',
+        strict=True,
+        incorrect_msg=bad_message_msg
+    )
 )
 Ex().success_msg("That's how it's done!")
 ```

--- a/chapter2.md
+++ b/chapter2.md
@@ -9,8 +9,8 @@ description : >-
 
 You may wonder what information is stored by each commit that you make. Git uses a three-level structure for this.
 
-1. A **commit** contains metadata such as the author, the commit message, and the time the commit happened. In the diagram below, commits are in the first column. The most recent commit is at the bottom (`feed0098`), and vertical arrows point up towards the previous ("parent") commits.
-2. Each commit also has a **tree**, which tracks the names and locations in the repository when that commit happened. These are shown in the second column. In the oldest (top) commit, there were two files tracked by the repository.
+1. A **commit** contains metadata such as the author, the commit message, and the time the commit happened. In the diagram below, the most recent commit is at the bottom (`feed0098`), and vertical arrows point up towards the previous ("parent") commits.
+2. Each commit also has a **tree**, which tracks the names and locations in the repository when that commit happened. In the oldest (top) commit, there were two files tracked by the repository.
 3. For each of the files listed in the tree, there is a **blob**. This contains a compressed snapshot of the contents of the file when the commit happened. (Blob is short for *binary large object*, which is a SQL database term for "may contain data of any kind".) In the middle commit, `report.md` and `draft.md` were changed, so the blobs are shown next to that commit. `data/northern.csv` didn't change in that commit, so the tree links to the blob from the previous commit. Reusing blobs between commits help make common operations fast and minimizes storage space.
 
 <img src="https://s3.amazonaws.com/assets.datacamp.com/production/course_5355/datasets/commit-tree-blob.png" alt="Commit-Tree-Blob Structure" />

--- a/chapter2.md
+++ b/chapter2.md
@@ -332,7 +332,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: 0cad38fb5f
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -366,7 +366,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 7b84819b84
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -399,7 +399,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 4545c769de
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 
@@ -518,7 +518,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: e3a590cd63
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -552,7 +552,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 4bbdbc8970
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -584,7 +584,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 0450972363
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 

--- a/chapter2.md
+++ b/chapter2.md
@@ -98,23 +98,25 @@ Ex().has_chosen(4, [err, err, err, "Correct!"])
 
 To view the details of a specific commit,
 you use the command `git show` with the first few characters of the commit's hash.
-For example, the command `git show 043070` produces this:
+For example, the command `git show 0da2f7` produces this:
 
-    commit 0430705487381195993bac9c21512ccfb511056d
-    Author: Rep Loop <repl@datacamp.com>
-    Date:   Wed Sep 20 13:42:26 2017 +0000
-    
-        Added year to report title.
-    
-    diff --git a/report.txt b/report.txt
-    index e713b17..4c0742a 100644
-    --- a/report.txt
-    +++ b/report.txt
-    @@ -1,4 +1,4 @@
-    -# Seasonal Dental Surgeries 2017-18
-    +# Seasonal Dental Surgeries (2017) 2017-18
-     
-     TODO: write executive summary.
+```{bash}
+commit 0da2f7ad11664ca9ed933c1ccd1f3cd24d481e42
+Author: Rep Loop <repl@datacamp.com>
+Date:   Wed Sep 5 15:39:18 2018 +0000
+
+    Added year to report title.
+
+diff --git a/report.txt b/report.txt
+index e713b17..4c0742a 100644
+--- a/report.txt
++++ b/report.txt
+@@ -1,4 +1,4 @@
+-# Seasonal Dental Surgeries 2017-18
++# Seasonal Dental Surgeries (2017) 2017-18
+
+ TODO: write executive summary.
+```
 
 The first part is the same as the log entry shown by `git log`.
 The second part shows the changes;
@@ -182,7 +184,7 @@ and that there cannot be spaces before or after the tilde.
 
 You are in the `dental` repository.
 Using a single Git command,
-look at the commit made just before the most recent one.
+show the commit made just before the most recent one.
 Which of the following files did it change?
 
 *** =instructions

--- a/chapter2.md
+++ b/chapter2.md
@@ -542,9 +542,9 @@ git status
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
-        has_code(r'\s*git\s+status\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = "Have a look at the status of your repository with `git status`.")
     )
 )
 ```
@@ -576,8 +576,8 @@ git clean -f
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(expr='ls | wc -l', output='4',
-                    incorrect_msg="Have you used `git clean -f` to get rid of the unwanted file that wasn't being tracked? After running it, `ls | wc -l` should give 4, but it didn't.")
+    has_expr_output(expr='ls', output=r'bin +data +report.txt +results',
+                    incorrect_msg="The directory doesn't contain only the tracked files. Have you used `git clean` with the `-f` flag?")
 )
 ```
 
@@ -607,9 +607,9 @@ ls
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Use `ls` to list the files in `dental`, your current working directory."),
-        has_code(r'\s*ls\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*ls\s*', incorrect_msg = "Use `ls` to list the files in `dental`, your current working directory.")
     )
 )
 Ex().success_msg("A job well done! Keeping your repository clean is crucial to keep oversight.")

--- a/chapter3.md
+++ b/chapter3.md
@@ -19,7 +19,7 @@ you should save your work in two separate commits.
 
 The syntax for staging a single file is `git add path/to/file`.
 
-If you make a mistake and accidentally commit a file you should have, you can unstage the additions with `git reset` and try again.
+If you make a mistake and accidentally commit a file you should have, you can unstage the additions with `git reset HEAD` and try again.
 
 *** =pre_exercise_code
 ```{python}
@@ -71,7 +71,7 @@ Ex().multi(
             output = 'data/eastern.csv',
             strict = True
         ),
-        incorrect_msg = "It seems that `data/eastern.csv` was added to the staging area. Unstage it with `git reset` then try again."
+        incorrect_msg = "It seems that `data/eastern.csv` was added to the staging area. Unstage it with `git reset HEAD` then try again."
     )
 )
 ```
@@ -291,8 +291,6 @@ git checkout -- data/northern.csv
 
 *** =sct1
 ```{python}
-Ex().check_not(has_code(r'git\s+status'), incorrect_msg="Alright, now that you've seen the status of the repo, use `git checkout` correctly to undo the changes to `data/northern.csv`.")
-
 msg = "After running your command, there should be no changes that can be staged. Have you used `git checkout` on `data/northern.csv` correctly? Make sure to use a `--` to separate the command from the name of the file."
 Ex().multi(
     has_cwd('/home/repl/dental'),
@@ -304,16 +302,14 @@ Ex().success_msg("Good job! This was about undoing changes that weren't staged y
 <!-- -------------------------------------------------------------------------------- -->
 
 --- type:BulletConsoleExercise key:fba584b9f1
-## How can I unstage a file that I have staged?
+## How can I undo changes to staged files?
 
-`git checkout -- filename` will undo changes that have not yet been staged.
-If you want to undo changes that *have* been staged,
-you can use `git reset HEAD filename`.
-This does *not* restore the file to the state it was in before you started making changes.
-Instead,
-it resets the file to the state you last staged.
-If you want to go all the way back to where you were before you started making changes,
-you must `git checkout -- filename` as well.
+At the start of this chapter you saw that `git reset` will unstage files that you previously staged using `git add`. By combining `git reset` with `git checkout`, you can undo changes to a file that you staged changes to. The syntax is as follows.
+
+```
+git reset HEAD path/to/file
+git checkout -- path/to/file
+```
 
 (You may be wondering why there are two commands for re-setting changes.
 The answer is that unstaging a file and undoing changes are both special cases
@@ -334,7 +330,7 @@ repl.run_command('git status')
 *** =type1: ConsoleExercise
 *** =key1: d0aa935274
 
-*** =xp1: 10
+*** =xp1: 5
 
 *** =instructions1
 
@@ -352,7 +348,7 @@ and the name of the file to be restored.
 
 *** =solution1
 ```{shell}
-git reset HEAD data/northern.csv
+git reset data/northern.csv
 ```
 
 *** =sct1
@@ -365,6 +361,37 @@ Ex().multi(
                     output='data/eastern.csv', strict=True, incorrect_msg=msg1),
     has_expr_output(expr='git diff --name-only | grep data/northern.csv',
                     output='data/northern.csv', strict=True, incorrect_msg=msg2)
+)
+```
+
+*** =type2: ConsoleExercise
+*** =key2: dc8ce69579
+
+*** =xp2: 5
+
+*** =instructions2
+
+Use `git checkout --` to undo the changes sicne the last commit for `data/northern.csv`.
+
+*** =hint2
+
+Use `git checkout` with two dashes and the name of the file to be restored.
+
+*** =sample_code2
+```{shell}
+```
+
+*** =solution2
+```{shell}
+git checkout -- data/northern.csv
+```
+
+*** =sct2
+```{python}
+msg = "After running your command, there should be no changes that can be staged. Have you used `git checkout` on `data/northern.csv` correctly? Make sure to use a `--` to separate the command from the name of the file."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only | wc -w', output='0', incorrect_msg=msg)
 )
 Ex().success_msg("That's how it's done!")
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -35,12 +35,12 @@ repl.run_command('git status')
 
 *** =instructions1
 
-Stage the changes made to `data/northern.csv`
-(and *only* those changes).
+From the output of `git status` on the right, you'll see that two files were changed; `data/northern.csv` and `data/eastern.csv`.
+Stage only the changes made to `data/northern.csv`.
 
 *** =hint1
 
-Use `git add` to stage the changes to a file.
+Use `git add` with a file path to stage the changes of this file.
 
 *** =sample_code1
 ```{shell}
@@ -53,9 +53,12 @@ git add data/northern.csv
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add\s+data/northern\.csv\s*',
-                           fixed=False,
-                           msg='Use `git add`.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep data/northern.csv',
+                    output = 'data/northern.csv',
+                    incorrect_msg = "It seems that `data/northern.csv` was not added to the staging area. Have you used `git add data/northern.csv`?")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -82,9 +85,14 @@ git commit -m "Adding data from northern region."
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit\s+-m.*',
-                           fixed=False,
-                           msg='Use `git commit` with a message.')
+msg = "It seems that the changes to `data/northern.csv` you staged in the previous instruction weren't committed. Have you used `git commit` with `-m \"message\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep data/northern.csv',
+                    output = 'data/northern.csv',
+                    incorrect_msg=msg)
+)
+Ex().success_msg("Well done! Let's have a look at re-staging files.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -139,9 +147,13 @@ git status
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status\s*',
-                           fixed=False,
-                           msg='Remember, you want to check the *status* of the repository.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
+        has_code(r'\s*git\s+status\s*')
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -151,7 +163,8 @@ Ex() >> test_student_typed(r'\s*git\s+status\s*',
 
 *** =instructions2
 
-Use `git add` to stage any files that have changes.
+It appers that some changes to `data/northern.csv` have already been staged, but there are new changes that haven't been staged yet.
+Use `git add` to stage these latest changes to `data/northern.csv` again.
 
 *** =hint2
 
@@ -168,9 +181,15 @@ git add data/northern.csv
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add\s+(data/northern\.csv|data/?|\.)\s*',
-                           fixed=False,
-                           msg='Use `git add` with one filename.')
+msg1 = "Have you used `git status data/northern.csv` to stage the latest changes to `data/northern.csv` as well?"
+msg2 = "It appears there are still changes to be staged. " + msg1
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep data/northern.csv',
+                    output='data/northern.csv', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff --name-only | wc -w', output='0', incorrect_msg=msg2)
+)
+Ex().success_msg("Alright! Let's expore how you can undo some of your work.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -205,7 +224,8 @@ with open('dental/data/eastern.csv', 'a') as writer:
 repl = connect('bash')
 repl.run_command('cd dental')
 repl.run_command('git add data/*.csv')
-repl.run_command('git status')
+with open('dental/data/northern.csv', 'a') as writer:
+    writer.write('2017-11-02,bicuspid\n')
 ```
 
 *** =type1: ConsoleExercise
@@ -215,9 +235,9 @@ repl.run_command('git status')
 
 *** =instructions1
 
-You are in the `dental` repository.
-Use one Git to undo the changes to the file `data/northern.csv`
-(and *only* that file).
+You are in the `dental` repository, where all changes to `.csv` files in `data` were staged. If you run `git status`, you will see that `data/northern.csv` was changed again.
+
+Use a Git command to undo the changes to the file `data/northern.csv`.
 
 *** =hint1
 
@@ -235,9 +255,14 @@ git checkout -- data/northern.csv
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+--\s+data/northern\.csv\s*',
-                           fixed=False,
-                           msg='Use `git checkout` with `--` as a separator and then a file.')
+Ex().check_not(has_code('git\s+status'), incorrect_msg="Alright, now that you've seen the status of the repo, use `git checkout` correctly to undo the changes to `data/northern.csv`.")
+
+msg = "After running your command, there should be no changes that can be staged. Have you used `git checkout` on `data/northern.csv` correctly? Make sure to use a `--` to separate the command from the name of the file."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only | wc -w', output='0', incorrect_msg=msg)
+)
+Ex().success_msg("Good job! This was about undoing changes that weren't staged yet. What about undoing changes that you staged already with `git add`? Find out in the next exercise.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -277,7 +302,7 @@ repl.run_command('git status')
 
 *** =instructions1
 
-Use a single Git command to unstage the file `data/northern.csv`
+Use `git reset` to unstage the file `data/northern.csv`
 (and *only* that file).
 
 *** =hint1
@@ -296,9 +321,16 @@ git reset HEAD data/northern.csv
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+reset\s+HEAD\s+data/northern\.csv\s*',
-                           fixed=False,
-                           msg='Use `git reset` with two arguments.')
+msg1 = "The checker expected the file `data/eastern.csv` to still be staged. Make sure to re-add it with `git add data/eastern.csv`."
+msg2 = "The checker expected `data/northern.csv` to no longer be staged. Have you used `git reset ___ data/northern.csv` (fill in the blank) correctly?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git diff --name-only --staged | grep data/eastern.csv',
+                    output='data/eastern.csv', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff --name-only | grep data/northern.csv',
+                    output='data/northern.csv', strict=True, incorrect_msg=msg2)
+)
+Ex().success_msg("That's how it's done!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -362,15 +394,16 @@ Use `git log` with the name of the file as an argument.
 
 *** =solution1
 ```{shell}
-# Run this command *without* 'cat' at the end.
+# Run this command without '| cat' at the end.
 git log report.txt | cat
 ```
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+log\s+report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git log` with a filename.')
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(incorrect_msg = "Have you used `git log ___` (fill in the blank)?")
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -393,14 +426,22 @@ Use `git checkout` with the hash and the name of the file as arguments (in that 
 
 *** =solution2
 ```{shell}
-git checkout a0a0a0a0 report.txt
+# Replace the commit hash with the penultimate hash from git log
+git checkout a0a0a0 report.txt
 ```
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+[0-9a-f]+\s+report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git checkout hash filename`.')
+msg = "The checker expected changes to `report.txt` to be staged. Have you used `git checkout ___ report.txt` (fill in the blank) to checkout the previous version correctly?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(expr='git diff --name-only --staged | grep report.txt',
+                        output='report.txt', strict=True, incorrect_msg=msg),
+        # to satisfy validator (as strict as possible)
+        has_code(r'\s*git\s+checkout\s+a0a0a0+\s+report\.txt\s*')
+    )
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -427,9 +468,19 @@ git commit -m "Restoring"
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit.*',
-                           fixed=False,
-                           msg='Use `git commit -m "message"`.')
+msg = "It seems that the changes to `report.txt` that were staged with the `git checkout` command weren't committed. Have you used `git commit` with `-m \"any message\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        multi(
+            has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt', output='report.txt', incorrect_msg=msg),
+            has_expr_output(expr='git diff --name-only --staged | wc -w', output='0', incorrect_msg=msg)
+        ),
+        # to satisfy validator (as strict as possible)
+        has_code(r'\s*git\s+commit\s+-m\s+"Restoring"')
+    )
+)
+Ex().success_msg("Solid, but there's more undoing to be done!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -458,7 +509,7 @@ with open('dental/report.txt', 'a') as writer:
     writer.write('\n(Because funding is the most important part of any project.)\n')
 repl = connect('bash')
 repl.run_command('cd dental')
-repl.run_command('git add dental')
+repl.run_command('git add .')
 repl.run_command('git status')
 ```
 
@@ -490,9 +541,14 @@ git reset HEAD .
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+reset\s+HEAD\s+(\.|dental)\s*',
-                           fixed=False,
-                           msg='Use `git reset HEAD` and some file or directory names.')
+instr=" Have you used `git reset HEAD .`?"
+msg1 = "It appears that there are still some staged files, while there shouldn't be any."+instr
+msg2 = "The checker expected to find three changed files that are not staged yet."+instr
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr = 'git diff --name-only --staged | wc -w', output='0', incorrect_msg=msg1),
+    has_expr_output(expr = 'git diff --name-only | wc -w', output='3', incorrect_msg=msg2)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -523,7 +579,15 @@ git checkout -- .
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+--\s+\.\s*',
-                           fixed=False,
-                           msg='Use `git checkout --` with `.` as an argument.')
+instr=" Have you used `git checkout -- .`?"
+msg1 = "It appears that there are some staged files, while there shouldn't be any."+instr
+msg2 = "The checker expected to find no files that still had changes to stage."+instr
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr = 'git diff --name-only --staged | wc -w', output='0',
+                    incorrect_msg=msg1),
+    has_expr_output(expr = 'git diff --name-only | wc -w', output='0',
+                    incorrect_msg=msg2)
+)
+Ex().success_msg("Well done! This concludes chapter 3 on undoing your work. Where Git gets really interesting, though, is in its branching abilities. Find out all about it in the next chapter!")
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -549,16 +549,13 @@ Ex().success_msg("Solid, but there's more undoing to be done!")
 --- type:BulletConsoleExercise key:d45eca9a34
 ## How can I undo all of the changes I have made?
 
-So far,
-you have seen how to undo changes to a single file at a time.
+So far, you have seen how to undo changes to a single file at a time using `git reset HEAD path/to/file`.
 You will sometimes want to undo changes to many files.
-One way to do this is to give `git reset` and `git checkout` a directory as an argument
-rather than the names of one or more files.
-For example,
-`git reset HEAD data` will unstage any files from the `data` directory that you have staged,
-and `git checkout -- data` will then restore those files to their previous state.
 
-Recall from [Introduction to Shell for Data Science](https://www.datacamp.com/courses/introduction-to-shell-for-data-science) that you can refer to the current directory as `.`.
+
+One way to do this is to give `git reset` a directory. For example, `git reset HEAD data` will unstage any files from the `data` directory. Even better, if you don't provide any files or directories, it will unstage everything. Even even better, `HEAD` is the default commit to unstage, so you can simply write `git reset` to unstage everything.
+
+Similarly `git checkout -- data` will then restore the files in the `data` directory to their previous state. You can't leave the file argument completely blank, but recall from [Introduction to Shell for Data Science](https://www.datacamp.com/courses/introduction-to-shell-for-data-science) that you can refer to the current directory as `.`. So `git checkout -- .` will revert all files in the current directory.
 
 *** =pre_exercise_code
 ```{python}
@@ -582,14 +579,10 @@ repl.run_command('git status')
 *** =instructions1
 
 Use `git reset` to remove all files from the staging area.
-Remember to give `git reset` two arguments:
-the revision to re-set to,
-and a directory name.
 
 *** =hint1
 
-The two arguments to `git reset` should be the name of the revision (which is `HEAD`)
-and the name of the current working directory (which is '.').
+Just call `git reset`.
 
 *** =sample_code1
 ```{shell}
@@ -597,12 +590,12 @@ and the name of the current working directory (which is '.').
 
 *** =solution1
 ```{shell}
-git reset HEAD .
+git reset
 ```
 
 *** =sct1
 ```{python}
-instr=" Have you used `git reset HEAD .`?"
+instr=" Have you used `git reset`?"
 msg1 = "It appears that there are still some staged files, while there shouldn't be any."+instr
 msg2 = "The checker expected to find three changed files that are not staged yet."+instr
 Ex().multi(

--- a/chapter3.md
+++ b/chapter3.md
@@ -12,10 +12,14 @@ You don't have to put all of the changes you have made recently into the staging
 For example,
 suppose you are adding a feature to `analysis.R`
 and spot a bug in `cleanup.R`.
-After you have fixed,
+After you have fixed it,
 you want to save your work.
 Since the changes to `cleanup.R` aren't directly related to the work you're doing in `analysis.R`,
 you should save your work in two separate commits.
+
+The syntax for staging a single file is `git add path/to/file`.
+
+If you make a mistake and accidentally commit a file you should have, you can unstage the additions with `git reset` and try again.
 
 *** =pre_exercise_code
 ```{python}
@@ -55,9 +59,20 @@ git add data/northern.csv
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(expr='git diff --name-only --staged | grep data/northern.csv',
-                    output = 'data/northern.csv',
-                    incorrect_msg = "It seems that `data/northern.csv` was not added to the staging area. Have you used `git add data/northern.csv`?")
+    has_expr_output(
+        expr = 'git diff --name-only --staged | grep data/northern.csv',
+        output = 'data/northern.csv',
+        strict = True,
+        incorrect_msg = "It seems that `data/northern.csv` was not added to the staging area. Have you used `git add data/northern.csv`?"
+    ),
+    check_not(
+        has_expr_output(
+            expr = 'git diff --name-only --staged | grep data/eastern.csv',
+            output = 'data/eastern.csv',
+            strict = True
+        ),
+        incorrect_msg = "It seems that `data/eastern.csv` was added to the staging area. Unstage it with `git reset` then try again."
+    )
 )
 ```
 
@@ -91,6 +106,26 @@ Ex().multi(
     has_expr_output(expr='git diff HEAD~ --name-only | grep data/northern.csv',
                     output = 'data/northern.csv',
                     incorrect_msg=msg)
+)
+not_committed_msg = "It seems that the staged changes to `data/northern.csv` weren't committed. Have you used `git commit` with `-m \"Adding data from northern region.\"`?"
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(
+            expr='git diff HEAD~ --name-only | grep data/northern.csv',
+            output = 'data/northern.csv',
+            strict=True,
+            incorrect_msg=not_committed_msg
+        ),
+        has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
+    ),
+    has_expr_output(
+        expr='git log -1 | grep --only-matching "Adding data from northern region"',
+        output = 'Adding data from northern region',
+        strict=True,
+        incorrect_msg=bad_message_msg
+    )
 )
 Ex().success_msg("Well done! Let's have a look at re-staging files.")
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -184,9 +184,9 @@ git status
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    check_or(
-        has_expr_output(incorrect_msg = "Have a look at the status of your repository with `git status`."),
-        has_code(r'\s*git\s+status\s*')
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = "Have a look at the status of your repository with `git status`.")
     )
 )
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -330,7 +330,7 @@ repl.run_command('git status')
 *** =type1: ConsoleExercise
 *** =key1: d0aa935274
 
-*** =xp1: 5
+*** =xp1: 50
 
 *** =instructions1
 
@@ -367,7 +367,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: dc8ce69579
 
-*** =xp2: 5
+*** =xp2: 50
 
 *** =instructions2
 

--- a/chapter3.md
+++ b/chapter3.md
@@ -401,14 +401,11 @@ Ex().success_msg("That's how it's done!")
 --- type:BulletConsoleExercise key:61872a66b5
 ## How do I restore an old version of a file?
 
-Since Git stores old versions of your files,
-you can use it to restore those files when you want to undo changes.
-The command for doing this is `git checkout`,
-which takes two arguments:
-the hash that identifies the version you want to restore,
-and the name of the file.
-For example,
-if `git log` shows this:
+You previously saw how to use `git checkout` to undo the change that you made since the last commit. This command can also be used to go back even further into a file's history and restore versions of that file from a commit. In this way, you can think of committing as saving your work, and **checking out** as loading that saved version.
+
+The syntax for restoring an old version takes two arguments: the hash that identifies the version you want to restore, and the name of the file.
+
+For example, if `git log` shows this:
 
 ```
 commit ab8883e8a6bfa873d44616a0f356125dbaccd9ea
@@ -424,15 +421,12 @@ Date:   Thu Oct 16 09:17:37 2017 -0400
     Modifying the bibliography format.
 ```
 
-then `git checkout 2242bd report.txt` would replace `report.txt`
-with whatever was committed on October 16.
+then `git checkout 2242bd report.txt` would replace the current version of `report.txt` with the version that was committed on October 16. Notice that this is the same syntax that you used to undo the unstaged changes, except `--` has been replaced by a hash.
 
 Restoring a file doesn't erase any of the repository's history.
-Instead,
-the act of restoring the file is saved as another commit,
-because you might later want to undo your undoing.
+Instead, the act of restoring the file is saved as another commit, because you might later want to undo your undoing.
 
-There's another feature of `git log` that will come in handy here. Passing `-` then a number restricts the output to that many commits. For example `git log -3 report.txt` shows you the last three commits involving `report.txt`.
+One more thing: there's another feature of `git log` that will come in handy here. Passing `-` then a number restricts the output to that many commits. For example, `git log -3 report.txt` shows you the last three commits involving `report.txt`.
 
 *** =pre_exercise_code
 ```{python}

--- a/chapter3.md
+++ b/chapter3.md
@@ -35,7 +35,7 @@ repl.run_command('git status')
 *** =type1: ConsoleExercise
 *** =key1: 387ad1a970
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -79,7 +79,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 381b4ed025
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 
@@ -160,7 +160,7 @@ with open('dental/data/northern.csv', 'a') as writer:
 *** =type1: ConsoleExercise
 *** =key1: b5a9b33d2e
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -194,7 +194,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 481636c0fc
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 
@@ -267,7 +267,7 @@ repl.run_command('git status')
 *** =type1: ConsoleExercise
 *** =key1: 9a5bde4d0b
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -441,7 +441,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: 8962ae79b3
 
-*** =xp1: 10
+*** =xp1: 35
 
 *** =instructions1
 
@@ -472,7 +472,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: a03a79d2de
 
-*** =xp2: 10
+*** =xp2: 35
 
 *** =instructions2
 
@@ -510,7 +510,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 00df157d59
 
-*** =xp3: 10
+*** =xp3: 30
 
 *** =instructions3
 
@@ -579,7 +579,7 @@ repl.run_command('git status')
 *** =type1: ConsoleExercise
 *** =key1: 5964997653
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -617,7 +617,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 3070c1d680
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 

--- a/chapter3.md
+++ b/chapter3.md
@@ -432,6 +432,8 @@ Instead,
 the act of restoring the file is saved as another commit,
 because you might later want to undo your undoing.
 
+There's another feature of `git log` that will come in handy here. Passing `-` then a number restricts the output to that many commits. For example `git log -3 report.txt` shows you the last three commits involving `report.txt`.
+
 *** =pre_exercise_code
 ```{python}
 repl = connect('bash')
@@ -445,11 +447,11 @@ repl.run_command('cd dental')
 
 *** =instructions1
 
-Use `git log` to list the recent changes to `report.txt`.
+Use `git log -1` to list the most recent changes to `report.txt`.
 
 *** =hint1
 
-Use `git log` with the name of the file as an argument.
+Use `git log -1` with the name of the file as an argument.
 
 *** =sample_code1
 ```{shell}
@@ -458,14 +460,14 @@ Use `git log` with the name of the file as an argument.
 *** =solution1
 ```{shell}
 # Run this command without '| cat' at the end.
-git log report.txt | cat
+git log -1 report.txt | cat
 ```
 
 *** =sct1
 ```{python}
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(incorrect_msg = "Have you used `git log ___` (fill in the blank)?")
+    has_expr_output(incorrect_msg = "Have you used `git log -1 ___` (fill in the blank)?")
 )
 ```
 
@@ -495,6 +497,8 @@ git checkout a0a0a0 report.txt
 
 *** =sct2
 ```{python}
+# Find the first 6 digits of the hash using
+# git log -1 report.txt | grep -P --only-matching "(?<=commit )[0-9a-f]{6}"
 msg = "The checker expected changes to `report.txt` to be staged. Have you used `git checkout ___ report.txt` (fill in the blank) to checkout the previous version correctly?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
@@ -502,7 +506,7 @@ Ex().multi(
         has_expr_output(expr='git diff --name-only --staged | grep report.txt',
                         output='report.txt', strict=True, incorrect_msg=msg),
         # to satisfy validator (as strict as possible)
-        has_code(r'\s*git\s+checkout\s+a0a0a0+\s+report\.txt\s*')
+        has_code(r'\s*git\s+checkout\s+0da2f7+\s+report\.txt\s*')
     )
 )
 ```

--- a/chapter3.md
+++ b/chapter3.md
@@ -255,7 +255,7 @@ git checkout -- data/northern.csv
 
 *** =sct1
 ```{python}
-Ex().check_not(has_code('git\s+status'), incorrect_msg="Alright, now that you've seen the status of the repo, use `git checkout` correctly to undo the changes to `data/northern.csv`.")
+Ex().check_not(has_code(r'git\s+status'), incorrect_msg="Alright, now that you've seen the status of the repo, use `git checkout` correctly to undo the changes to `data/northern.csv`.")
 
 msg = "After running your command, there should be no changes that can be staged. Have you used `git checkout` on `data/northern.csv` correctly? Make sure to use a `--` to separate the command from the name of the file."
 Ex().multi(

--- a/chapter3.md
+++ b/chapter3.md
@@ -261,6 +261,7 @@ repl.run_command('cd dental')
 repl.run_command('git add data/*.csv')
 with open('dental/data/northern.csv', 'a') as writer:
     writer.write('2017-11-02,bicuspid\n')
+repl.run_command('git status')
 ```
 
 *** =type1: ConsoleExercise
@@ -270,7 +271,7 @@ with open('dental/data/northern.csv', 'a') as writer:
 
 *** =instructions1
 
-You are in the `dental` repository, where all changes to `.csv` files in `data` were staged. If you run `git status`, you will see that `data/northern.csv` was changed again.
+You are in the `dental` repository, where all changes to `.csv` files in `data` were staged.  `git status` shows that `data/northern.csv` was changed again after it was staged.
 
 Use a Git command to undo the changes to the file `data/northern.csv`.
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -366,8 +366,10 @@ Ex().success_msg("Quite a journey! In the next few exercises, you'll practice so
 --- type:BulletConsoleExercise key:51c4cb1dc0
 ## How can I create a branch?
 
-The easiest way to create a new branch is to run `git checkout -b branch-name`,
-which creates the branch and switches you to it.
+You might expect that you would use `git branch` to create a branch, and indeed this is possible. However, the most common thing you want to do is to create a branch then switch to that branch.
+
+In the previous exercise, you used `git checkout branch-name` to switch to a branch. To create a branch then switch to it in one step, you add a `-b` flag, calling `git checkout -b branch-name`,
+
 The contents of the new branch are initially identical to the contents of the original.
 Once you start making changes,
 they only affect the new branch.
@@ -515,10 +517,14 @@ git diff master..deleting-report
 *** =sct4
 ```{python}
 msg = 'Use `git diff branch-1..branch-2` to compare branches. Replace `branch-1` and `branch-2` with the appropriate names for this context.'
-Ex().check_or(
-    has_expr_output(incorrect_msg = msg),
-    has_expr_output(code = 'git diff deleting-report..master', incorrect_msg = msg)
-)
+# The sensible solution below causes the exercise to hang if the student types git diff with no arguments.
+# So just do regex matching instead.
+# Ex().check_or(
+#     has_expr_output(strict = True, incorrect_msg = msg),
+#     has_expr_output(code = 'git diff deleting-report..master', incorrect_msg = msg, strict = True),
+#     has_code(r'\s*git\s+diff\s*(deleting-report\.\.master|master\.\.deleting-report)', incorrect_msg = msg)
+# )
+Ex().has_code(r'\s*git\s+diff\s*(deleting-report\.\.master|master\.\.deleting-report)', incorrect_msg = msg)
 Ex().success_msg("Well done. Let's have a look at merging branches now.")
 ```
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -151,7 +151,7 @@ repl.run_command('git branch')
 *** =type1: ConsoleExercise
 *** =key1: eee4722074
 
-*** =xp1: 10
+*** =xp1: 16
 
 *** =instructions1
 
@@ -185,7 +185,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 6193872406
 
-*** =xp2: 10
+*** =xp2: 16
 
 *** =instructions2
 
@@ -220,7 +220,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: dcfdc86805
 
-*** =xp3: 10
+*** =xp3: 16
 
 *** =instructions3
 
@@ -255,7 +255,7 @@ Ex().multi(
 *** =type4: ConsoleExercise
 *** =key4: 99b72ed9cb
 
-*** =xp4: 10
+*** =xp4: 16
 
 *** =instructions4
 
@@ -288,7 +288,7 @@ Ex().multi(
 *** =type5: ConsoleExercise
 *** =key5: 4afc727945
 
-*** =xp5: 10
+*** =xp5: 16
 
 *** =instructions5
 
@@ -320,7 +320,7 @@ Ex().multi(
 *** =type6: ConsoleExercise
 *** =key6: b0b5946436
 
-*** =xp6: 10
+*** =xp6: 20
 
 *** =instructions6
 
@@ -366,7 +366,7 @@ repl.run_command('git branch')
 *** =type1: ConsoleExercise
 *** =key1: 71253d1c95
 
-*** =xp1: 10
+*** =xp1: 25
 
 *** =instructions1
 
@@ -406,7 +406,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 4dc64f3a09
 
-*** =xp2: 10
+*** =xp2: 25
 
 *** =instructions2
 
@@ -441,7 +441,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: a7e82dfb0c
 
-*** =xp3: 10
+*** =xp3: 25
 
 *** =instructions3
 
@@ -476,7 +476,7 @@ Ex().multi(
 *** =type4: ConsoleExercise
 *** =key4: ec7d242138
 
-*** =xp4: 10
+*** =xp4: 25
 
 *** =instructions4
 
@@ -533,7 +533,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: 7a4bb39d31
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -669,7 +669,7 @@ repl.run_command('git branch')
 *** =type1: ConsoleExercise
 *** =key1: 1e11825f95
 
-*** =xp1: 10
+*** =xp1: 20
 
 *** =instructions1
 
@@ -707,7 +707,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 9ecd08b08b
 
-*** =xp2: 10
+*** =xp2: 20
 
 *** =instructions2
 
@@ -740,7 +740,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 4acfdd12bd
 
-*** =xp3: 10
+*** =xp3: 20
 
 *** =instructions3
 
@@ -798,7 +798,7 @@ Ex().multi(
 *** =type4: ConsoleExercise
 *** =key4: 323f9a133c
 
-*** =xp4: 10
+*** =xp4: 20
 
 *** =instructions4
 
@@ -833,7 +833,7 @@ Ex().multi(
 *** =type5: ConsoleExercise
 *** =key5: d9b25e272f
 
-*** =xp5: 10
+*** =xp5: 20
 
 *** =instructions5
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -173,7 +173,7 @@ git checkout summary-statistics
 
 *** =sct1
 ```{python}
-msg="You don't appear tho be on the right branch. Have you used `git checkout summary-statistics`?"
+msg="You don't appear to be on the right branch. Have you used `git checkout summary-statistics`?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
     # Check we're on the right branch -- https://stackoverflow.com/a/12142066/1144523
@@ -309,7 +309,7 @@ git checkout master
 
 *** =sct5
 ```{python}
-msg="You don't appear tho be on the right branch. Have you used `git checkout master`?"
+msg="You don't appear to be on the right branch. Have you used `git checkout master`?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
@@ -395,9 +395,9 @@ Ex().multi(
         has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep deleting-report',
                         output='deleting-report', strict=True, incorrect_msg=msg),
         multi(
-            has_code('git\s+checkout', incorrect_msg="Have you used `git checkout`?"),
-            has_code('-b', incorrect_msg="Make sure to use the flag `-b`."),
-            has_code('deleting-report', incorrect_msg="Your new branch should be called `deleting-report`. Beware of typos!")
+            has_code(r'git\s+checkout', incorrect_msg="Have you used `git checkout`?"),
+            has_code(r'-b', incorrect_msg="Make sure to use the flag `-b`."),
+            has_code(r'deleting-report', incorrect_msg="Your new branch should be called `deleting-report`. Beware of typos!")
         )
     )
 )
@@ -788,9 +788,9 @@ Ex().multi(
                     output='master', strict=True, incorrect_msg=msg1),
     check_file('/home/repl/dental/report.txt').multi(
         has_code('# Dental Work by Season 2017-18', fixed=True, incorrect_msg=msg2),
-        check_not(has_code('<<<<<'), incorrect_msg=msg3patt%'<<<<<<<'),
-        check_not(has_code('>>>>>'), incorrect_msg=msg3patt%'>>>>>>>'),
-        check_not(has_code('====='), incorrect_msg=msg3patt%'=======')
+        check_not(has_code(r'<<<<<'), incorrect_msg=msg3patt%'<<<<<<<'),
+        check_not(has_code(r'>>>>>'), incorrect_msg=msg3patt%'>>>>>>>'),
+        check_not(has_code(r'====='), incorrect_msg=msg3patt%'=======')
     )
 )
 ```

--- a/chapter4.md
+++ b/chapter4.md
@@ -8,14 +8,14 @@ description : >-
 --- type:PureMultipleChoiceExercise lang:bash xp:50 key:9db055a148
 ## What is a branch?
 
-One of the reasons Git is popular is its support for creating **branches**.
-A branch is like a parallel universe:
-changes you make in one branch do not affect other branches until you **merge** them back together.
-It's like creating sub-directories called `final`, `final-updated`, `final-updated-revised`, and so on,
-but with support for tracking work systematically.
+If you don't use version control, a common workflow is to create different subdirectories to hold different versions of your project in different states, for example `development` and `final`. Of course, then you always end up with `final-updated` and `final-updated-revised` as well. The problem with this is that it becomes difficult to work out if you have the right version of each file in the right subdirectory, and you risk losing work.
+
+One of the reasons Git is popular is its support for creating **branches**, which allows you to have multiple versions of your work, and lets you track each version systematically.
+
+Each branch is like a parallel universe: changes you make in one branch do not affect other branches (until you **merge** them back together).
 
 Note:
-the first chapter described the three-part data structure Git uses to record a repository's history:
+Chapter 2 described the three-part data structure Git uses to record a repository's history:
 *blobs* for files,
 *trees* for the saved states of the repositories,
 and *commits* to record the changes.
@@ -24,8 +24,8 @@ a commit will have two parents when branches are being merged.
 
 <hr>
 
-If each box in this diagram is a commit,
-how many merges have taken place?
+In the diagram below, each box is a commit and the arrows point to the next ("child") commit.
+How many merges have taken place?
 
 <img src="https://s3.amazonaws.com/assets.datacamp.com/production/course_5355/datasets/branching.png" alt="Branching and Merging" />
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -514,9 +514,10 @@ git diff master..deleting-report
 
 *** =sct4
 ```{python}
+msg = 'Use `git diff branch-1..branch-2` to compare branches. Replace `branch-1` and `branch-2` with the appropriate names for this context.'
 Ex().check_or(
-    has_expr_output(incorrect_msg='Use `git diff branch-1..branch-2` to compare branches. Replace `branch-1` and `branch-2` with the appropriate names for this context.'),
-    has_expr_output(code='git diff deleting-report..master')
+    has_expr_output(incorrect_msg = msg),
+    has_expr_output(code = 'git diff deleting-report..master', incorrect_msg = msg)
 )
 Ex().success_msg("Well done. Let's have a look at merging branches now.")
 ```

--- a/chapter4.md
+++ b/chapter4.md
@@ -132,14 +132,14 @@ Ex().has_chosen(3, ['No: some files differ.',
 --- type:BulletConsoleExercise key:c418145d13
 ## How can I switch from one branch to another?
 
-When you run `git branch`,
-it puts a `*` beside the name of the branch you are currently in.
-To switch to another branch,
-you use `git checkout branch-name`.
+You previously used `git checkout` with a commit hash to switch the repository state to that hash. You can also use `git checkout` with the name of a branch to switch to that branch.
 
-Note: Git will only let you do this if all of your changes have been committed.
-You can get around this,
-but it is outside the scope of this course.
+Two notes: 
+
+1. When you run `git branch`, it puts a `*` beside the name of the branch you are currently in. 
+2. Git will only let you do this if all of your changes have been committed. You can get around this, but it is outside the scope of this course.
+
+In this exercise, you'll also make use of `git rm`. This removes the file (just like the shell command `rm`) then stages the removal of that file with `git add`, all in one step.
 
 *** =pre_exercise_code
 ```{python}
@@ -173,7 +173,7 @@ git checkout summary-statistics
 
 *** =sct1
 ```{python}
-msg="You don't appear to be on the right branch. Have you used `git checkout summary-statistics`?"
+msg="You don't appear to be on the right branch. Have you used `git checkout` to go to the `summary-statistics` branch?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
     # Check we're on the right branch -- https://stackoverflow.com/a/12142066/1144523
@@ -241,14 +241,30 @@ git commit -m "Removing report"
 
 *** =sct3
 ```{python}
-msg1="Make sure you stay on the `summary-statistics` branch. Use `git checkout summary-statistics` to navigate back."
-msg2="It seems that the staged deletion of `report.txt` wasn't committed. Use `git commit` with `-m \"any message\"`."
+branch_msg =" Make sure you stay on the `summary-statistics` branch. Use `git checkout summary-statistics` to navigate back."
+not_committed_msg = "It seems that the staged changes to `report.txt` weren't committed. Have you used `git commit` with `-m \"Removing report\"`?"
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
-                    output='summary-statistics', strict=True, incorrect_msg=msg1),
-    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
-                    output = 'report.txt', incorrect_msg=msg2)
+    has_expr_output(
+        expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
+        output='summary-statistics', strict=True, incorrect_msg=branch_msg
+    ),
+    check_or(
+        has_expr_output(
+            expr='git diff HEAD~ --name-only | grep report.txt',
+            output = 'report.txt',
+            strict=True,
+            incorrect_msg=not_committed_msg
+        ),
+        has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
+    ),
+    has_expr_output(
+        expr='git log -1 | grep --only-matching "Removing report"',
+        output = 'Removing report',
+        strict=True,
+        incorrect_msg=bad_message_msg
+    )
 )
 ```
 

--- a/chapter4.md
+++ b/chapter4.md
@@ -39,7 +39,7 @@ how many merges have taken place?
 
 Look for boxes with two arrows coming into them.
 
-*** =feedbacks
+*** =feedback
 - No: some commits have more than one parent.
 - No: some commits have more than one parent.
 - Correct: two commits have more than one parent.
@@ -80,7 +80,7 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(4, ['No: every repository has at least one branch.',
+Ex().has_chosen(4, ['No: every repository has at least one branch.',
                     'No: there are more branches than that.',
                     'No: there are more branches than that.',
                     'Correct!'])
@@ -121,7 +121,7 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(3, ['No: some files differ.',
+Ex().has_chosen(3, ['No: some files differ.',
                     'No: please count both files that have changed and files that are being added.',
                     'Correct!',
                     'No: please count the number of files that differ, not the number of lines that are different.'])
@@ -173,9 +173,13 @@ git checkout summary-statistics
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+summary-statistics\s*',
-                           fixed=False,
-                           msg='Use `git checkout` to switch between branches.')
+msg="You don't appear tho be on the right branch. Have you used `git checkout summary-statistics`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    # Check we're on the right branch -- https://stackoverflow.com/a/12142066/1144523
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
+                    output='summary-statistics', strict=True, incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -202,9 +206,15 @@ git rm report.txt
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+rm\s+report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git rm filename`.')
+msg1="Make sure you stay on the `summary-statistics` branch. Use `git checkout summary-statistics` to navigate back."
+msg2="It seems that the deletion of `report.txt` was not staged. Have you used `git rm report.txt`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
+                    output='summary-statistics', strict=True, incorrect_msg=msg1),
+    has_expr_output('git diff --name-only --staged | grep report.txt',
+                    output='report.txt', strict=True, incorrect_msg=msg2)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -231,9 +241,15 @@ git commit -m "Removing report"
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit.+\s*',
-                           fixed=False,
-                           msg='Use `git commit -m "message"`.')
+msg1="Make sure you stay on the `summary-statistics` branch. Use `git checkout summary-statistics` to navigate back."
+msg2="It seems that the staged deletion of `report.txt` wasn't committed. Use `git commit` with `-m \"any message\"`."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
+                    output='summary-statistics', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
+                    output = 'report.txt', incorrect_msg=msg2)
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -260,9 +276,13 @@ ls
 
 *** =sct4
 ```{python}
-Ex() >> test_student_typed(r'\s*ls\s*',
-                           fixed=False,
-                           msg='Use `ls` without any parameters.')
+msg="Make sure you stay on the `summary-statistics` branch. Use `git checkout summary-statistics` to navigate back."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep summary-statistics',
+                    output='summary-statistics', strict=True, incorrect_msg=msg),
+    has_expr_output(incorrect_msg="Have you used `ls` correctly? `report.txt` should have disappeared.")
+)
 ```
 
 *** =type5: ConsoleExercise
@@ -289,9 +309,12 @@ git checkout master
 
 *** =sct5
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+master\s*',
-                           fixed=False,
-                           msg='Use `git checkout` to switch between branches.')
+msg="You don't appear tho be on the right branch. Have you used `git checkout master`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg)
+)
 ```
 
 *** =type6: ConsoleExercise
@@ -318,9 +341,8 @@ ls
 
 *** =sct6
 ```{python}
-Ex() >> test_student_typed(r'\s*ls\s*',
-                           fixed=False,
-                           msg='Use `ls` without any parameters.')
+Ex().has_expr_output(incorrect_msg="Have you used `ls` correctly? `report.txt` should have disappeared.")
+Ex().success_msg("Quite a journey! In the next few exercises, you'll practice some more with navigating branches and staging and committing changes.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -366,9 +388,19 @@ git checkout -b deleting-report
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+-b\s+deleting-report\s*',
-                           fixed=False,
-                           msg='Use `git checkout -b` to create a branch.')
+msg="Have you used `git checkout -b deleting-report?` to create a new branch and switch to it?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_correct(
+        has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep deleting-report',
+                        output='deleting-report', strict=True, incorrect_msg=msg),
+        multi(
+            has_code('git\s+checkout', incorrect_msg="Have you used `git checkout`?"),
+            has_code('-b', incorrect_msg="Make sure to use the flag `-b`."),
+            has_code('deleting-report', incorrect_msg="Your new branch should be called `deleting-report`. Beware of typos!")
+        )
+    )
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -395,9 +427,15 @@ git rm report.txt
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+rm\s+report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git rm filename`.')
+msg1="Make sure you stay on the `deleting-report` branch. Use `git checkout deleting-report` to navigate back."
+msg2="It seems that the deletion of `report.txt` was not staged. Have you used `git rm report.txt`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep deleting-report',
+                    output='deleting-report', strict=True, incorrect_msg=msg1),
+    has_expr_output('git diff --name-only --staged | grep report.txt',
+                    output='report.txt', strict=True, incorrect_msg=msg2)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -424,9 +462,15 @@ git commit -m "Deleting report"
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit.+\s*',
-                           fixed=False,
-                           msg='Use `git commit -m "message"`.')
+msg1="Make sure you stay on the `deleting-report` branch. Use `git checkout deleting-report` to navigate back."
+msg2="It seems that the staged deletion of `report.txt` wasn't committed. Use `git commit` with `-m \"any message\"`."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep deleting-report',
+                    output='deleting-report', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt',
+                    output = 'report.txt', incorrect_msg=msg2)
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -454,9 +498,11 @@ git diff master..deleting-report
 
 *** =sct4
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+diff\s+(master\.\.deleting-report|deleting-report\.\.master)\s*',
-                           fixed=False,
-                           msg='Use `git diff branch-1..branch-2` to compare branches.')
+Ex().check_or(
+    has_expr_output(incorrect_msg='Use `git diff branch-1..branch-2` to compare branches. Replace `branch-1` and `branch-2` with the appropriate names for this context.'),
+    has_expr_output(code='git diff deleting-report..master')
+)
+Ex().success_msg("Well done. Let's have a look at merging branches now.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -508,14 +554,23 @@ and `master` as the second (the "to" branch).
 *** =solution1
 ```{shell}
 # Run this command *without* the '-no-edit' flag:
-git merge --no-edit -m "Merging summary statistics" summary-statistics master
+git merge --no-edit summary-statistics master
 ```
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+merge.*\s+summary-statistics\s+master\s*',
-                           fixed=False,
-                           msg='Use `git merge branch branch`.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+msg2 = "Have you used `git merge summary-statistics master` to merge `summary-statistics` into `master`? An editor will show up. You can use Ctrl+O and then Ctrl+X to exit this. If you want to avoid this, use the `--no-edit` flag in the `git merge` command."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep bin/summary',
+                    output = 'bin/summary', incorrect_msg=msg2),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep results/summary.txt',
+                    output = 'results/summary.txt', incorrect_msg=msg2)
+)
+Ex().success_msg("Merged it! Well done!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -568,7 +623,7 @@ what conflicts does Git report?
 
 Look for lines with `+` or `-` in front of them.
 
-*** =feedbacks
+*** =feedback
 - Correct: Git can merge the deletion of line A and the addition of line C automatically.
 - No: Git can merge the deletion of line A automatically.
 - No: Git can merge the addition of line C automatically.
@@ -638,9 +693,15 @@ git merge --no-edit -m "Merging altered report title" alter-report-title master
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git merge.+alter-report-title\s*master\s*',
-                           fixed=False,
-                           msg='Use `git merge branch branch`.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+msg2 = "Have you used `git merge summary-statistics master` to merge `alter-report-title` into `master`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    # git diff -name-only should return report.txt twice after unsuccessful merge
+    has_expr_output(expr='git diff --name-only | grep report.txt | wc -w', output = '2', incorrect_msg=msg2)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -667,9 +728,13 @@ git status
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status(.+)?\s*',
-                           fixed=False,
-                           msg='Use `git status`.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(incorrect_msg="Have you used `git status` to see the status of your repo?")
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -679,11 +744,17 @@ Ex() >> test_student_typed(r'\s*git\s+status(.+)?\s*',
 
 *** =instructions3
 
-Use `nano` to edit the file and remove the conflict markers.
+It turns out that `report.txt` has some conflicts. Use `nano report.txt` to open it and remove some lines so that only the second title is kept. Save you work with Ctrl+O and leave the editor with Ctrl+X. You can easily remove entire lines with Ctrl+K
 
 *** =hint3
 
-Use `nano` and the filename.
+Use `nano` and the filename. Remove the following lines:
+
+- `<<<<<<< HEAD`
+- `# Seasonal Dental Surgeries (2017) 2017-18`
+- `=======`
+- `>>>>>>> alter-report-title`
+
 
 *** =sample_code3
 ```{shell}
@@ -691,15 +762,37 @@ Use `nano` and the filename.
 
 *** =solution3
 ```{shell}
-# Run this command *without* 'echo' at the front:
-echo nano report.txt
+# This solution uses another command
+# because our automated tests can't edit files interactively.
+echo -e '
+# Dental Work by Season 2017-18
+
+TODO: write executive summary.
+
+TODO: include link to raw data.
+
+TODO: remember to cite funding sources!
+
+' > report.txt
 ```
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'.*nano\s+report\.txt.*',
-                           fixed=False,
-                           msg='Use `nano filename`.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+edit=" Edit the file again with `nano report.txt` and make some more changes."
+msg2 = "The title `# Dental Work by Season 2017-18` disappeared from `report.txt`, while that was the title to keep!" + edit
+msg3patt = "It seems that there is a still a conflict marker (`%s`) in the `report.txt` file. Make sure to remove this line entirely." + edit
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    check_file('/home/repl/dental/report.txt').multi(
+        has_code('# Dental Work by Season 2017-18', fixed=True, incorrect_msg=msg2),
+        check_not(has_code('<<<<<'), incorrect_msg=msg3patt%'<<<<<<<'),
+        check_not(has_code('>>>>>'), incorrect_msg=msg3patt%'>>>>>>>'),
+        check_not(has_code('====='), incorrect_msg=msg3patt%'=======')
+    )
+)
 ```
 
 *** =type4: ConsoleExercise
@@ -726,9 +819,15 @@ git add report.txt
 
 *** =sct4
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s*add\s*report\.txt\s*',
-                           fixed=False,
-                           msg='Use `git add filename` as usual.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff --name-only --staged | grep report.txt',
+                    output = 'report.txt',
+                    incorrect_msg = "It seems that `report.txt` was not added to the staging area. Have you used `git add report.txt`?")
+)
 ```
 
 *** =type5: ConsoleExercise
@@ -755,7 +854,14 @@ git commit -m "Reconciling"
 
 *** =sct5
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit.+\s*',
-                           fixed=False,
-                           msg='Use `git commit` as usual.')
+msg1 = "Make sure you are on the `master` branch when you do the `git merge` command. Use `git checkout master` first."
+msg2 = "It seems that the changes to `report.txt` that were staged with the `git add` command weren't committed. Have you used `git commit` with `-m \"any message\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+            output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep report.txt', output='report.txt',     incorrect_msg=msg2),
+    has_expr_output(expr='git diff --name-only --staged | wc -w', output='0', incorrect_msg=msg2)
+)
+Ex().success_msg("Well done! This was quite a challenge. A final yet extremely important aspect about Git is collaboration. Learn all about it in the fifth and final chapter of this course!")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -134,7 +134,10 @@ git status
 msg="Have you used `git status` to look at the status of your freshly initialized repository?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
-    has_expr_output(incorrect_msg=msg)
+    check_correct(
+        has_expr_output(),
+        has_code(r'\s*git\s+status\s*', incorrect_msg = msg)
+    )
 )
 Ex().success_msg("Interesting: after initializing the folder into a repository, Git immediately notices that there are a bunch of changes that can be staged (and afterwards, committed).")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -31,9 +31,13 @@ git init optical
 
 *** =sct
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+init\s+optical\s*',
-                           fixed=False,
-                           msg='Use `git init` and a directory name.')
+msgpatt = "There is no folder %s in %s. Have you used `git init optical` appropriately to create a new Git repository?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_dir('/home/repl/optical', incorrect_msg=msgpatt % ('`optical`', '`/home/repl`')),
+    has_dir('/home/repl/optical/.git', incorrect_msg=msgpatt % ('`.git`', 'the `optical` folder'))
+)
+Ex().success_msg("Well done! This was starting from scratch, but you'll often want to turn an existing folder into a Git repo as well. Find out how in the next exercise.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -47,8 +51,19 @@ though,
 or working with people who are,
 you will often want to convert existing projects into repositories.
 Doing so is simple:
-just run `git init` in the project's root directory,
-or `git init /path/to/project` from anywhere else on your computer.
+just run
+
+```
+git init
+```
+
+in the project's root directory, or 
+
+```
+git init /path/to/project
+```
+
+from anywhere else on your computer.
 
 *** =pre_exercise_code
 ```{python}
@@ -85,9 +100,11 @@ git init
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+init\s*',
-                           fixed=False,
-                           msg='Use `git init`.')
+msg = "There is no `.git` folder in `dental`. Are you sure you used `git init` correctly?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_dir('/home/repl/dental/.git', incorrect_msg=msg)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -114,12 +131,14 @@ git status
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+status\s*',
-                           fixed=False,
-                           msg='Check the status as you normally would.')
+msg="Have you used `git status` to look at the status of your freshly initialized repository?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(incorrect_msg=msg)
+)
+Ex().success_msg("Interesting: after initializing the folder into a repository, Git immediately notices that there are a bunch of changes that can be staged (and afterwards, committed).")
 ```
 
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:BulletConsoleExercise key:9fb3b2ed49
 ## How can I create a copy of an existing repository?
@@ -135,9 +154,19 @@ it creates a copy of an existing repository (including all of its history) in a 
 To clone a repository,
 use the command `git clone URL`,
 where `URL` identifies the repository you want to clone.
-This will normally be something like `https://github.com/datacamp/project.git`,
+This will normally be something like 
+
+```
+https://github.com/datacamp/project.git
+```
+
 but for this lesson,
-we will use **filesystem URLs** of the form `file:///existing/project`.
+we will use **filesystem URLs** of the form 
+
+```
+file:///existing/project
+```
+
 The number of slashes at the start is important:
 the first part of the URL is `file://`,
 and then there is a third slash to start the absolute path `/existing/project`.
@@ -145,9 +174,18 @@ and then there is a third slash to start the absolute path `/existing/project`.
 When you clone a repository,
 Git uses the name of the existing repository as the name of the clone's root directory:
 for example,
-`git clone file:///existing/project` will create a new directory called `project`.
+
+```
+git clone file:///existing/project
+```
+
+will create a new directory called `project`.
 If you want to call the clone something else,
-add the directory name you want to the command: `git clone file:///existing/project newprojectname`
+add the directory name you want to the command:
+
+```
+git clone file:///existing/project newprojectname
+```
 
 *** =pre_exercise_code
 ```{python}
@@ -155,6 +193,7 @@ repl = connect('bash')
 repl.run_command('rm -rf dental')
 repl.run_command('clear')
 repl.run_command('pwd')
+repl.run_command('ls')
 ```
 
 *** =type1: ConsoleExercise
@@ -181,14 +220,17 @@ Remember to count the slashes after `file:` carefully.
 *** =solution1
 ```{shell}
 git clone file:///home/thunk/repo dental
-pwd
 ```
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+clone\s+file:///home/thunk/repo\s+(/home/repl/|~/|\./|)?dental\s*',
-                           fixed=False,
-                           msg='Use `git clone` and the absolute or relative path of the directory to clone to.')
+msgpatt = "There is no folder %s in %s. Have you used `git clone file:///home/thunk/repo dental` to copy the repository from /home/thunk/repo?"
+Ex().multi(
+    has_cwd('/home/repl'),
+    has_dir('/home/repl/dental', incorrect_msg=msgpatt % ('`dental`', '`/home/repl`')),
+    has_dir('/home/repl/dental/.git', incorrect_msg=msgpatt % ('`.git`', 'the `dental` folder'))
+)
+Ex().success_msg("Well done! Let's continue!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -234,7 +276,7 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex() >> test_mc(2, ['No: there are some remotes.',
+Ex().has_chosen(2, ['No: there are some remotes.',
                     'Correct!',
                     'No: there is just one remote.'])
 ```
@@ -294,9 +336,15 @@ git remote add thunk file:///home/thunk/repo
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+remote\s+add\s+thunk\s+file:///home/thunk/repo\s*',
-                           fixed=False,
-                           msg='Use `git remote add` with the name and URL of the remote.')
+msg1="The system couldn't find a remote with the name `thunk`. Have you used `git remote add thunk <path_to_remote>`?"
+msg2="Are you sure the path of the thunk remote is correct? Have you used `git remote add thunk file:///home/thunk/repo`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output('git remote', output='thunk', strict=True, incorrect_msg=msg1),
+    has_expr_output('git remote get-url thunk',
+                    output='file:///home/thunk/repo', strict=True, incorrect_msg=msg2)
+)
+Ex().success_msg("Neat! Now you added a remote to your local git repository.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -360,12 +408,18 @@ git pull origin master
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+pull\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git pull` with the name of the remote and the name of the branch.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "If you correctly called `git pull origin master`, the last commit on the `master` should be one from the remote, but it turns out that's not the case. Try again."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output("git log -1 --pretty=%B | grep Reminder", output="Reminder to add references to report.",
+                    incorrect_msg=msg2)
+)
+Ex().success_msg("Well done! This `git pull` went smoothly, but unfortunately that's not always the case. Let's see what can happen if you have unsaved changes when trying to pull in changes.")
 ```
 
-<!-- -------------------------------------------------------------------------------- -->
 
 --- type:BulletConsoleExercise key:2b1e228738
 ## What happens if I try to pull when I have unsaved changes?
@@ -414,9 +468,15 @@ git pull origin master
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+pull\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git pull origin master` to pull in changes.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "If you correctly called `git pull origin master`, the last commit on the `master` should be one from the remote, but it turns out that's not the case. Try again."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_code(r'\s*git\s+pull\s+origin\s+master\s*',
+              fixed=False, incorrect_msg='Use `git pull origin master` to pull in changes.')
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -430,7 +490,7 @@ Discard the changes in your repository.
 
 *** =hint2
 
-Read the message printed by `git pull` for a reminder of how to do this.
+Remember: `git checkout` resets all changes to unstaged files.
 
 *** =sample_code2
 ```{shell}
@@ -443,9 +503,14 @@ git checkout -- .
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+checkout\s+--.*',
-                           fixed=False,
-                           msg='Use `git checkout --` and a path.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "After running your command, there should be no changes to stage anymore. Have you used `git checkout -- .`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff --name-only | wc -w', output='0', incorrect_msg=msg2)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -472,9 +537,16 @@ git pull origin master
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+pull\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git pull origin master` to pull in changes.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "If you correctly called `git pull origin master`, the last commit on the `master` should be one from the remote, but it turns out that's not the case. Try again."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output("git log -1 --pretty=%B | grep Reminder", output="Reminder to add references to report.",
+                    incorrect_msg=msg2)
+)
+Ex().success_msg("Well done! Remember: you should have committed all your local changes if you want your `git pull` to run smoothly.")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -535,9 +607,15 @@ git add data/northern.csv
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+add.+\s*',
-                           fixed=False,
-                           msg='Use `git add` as normal.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "It seems that `data/northern.csv` wasn't added to the staging area. Have you used `git add data/northern.csv`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff --name-only --staged | grep data/northern.csv',
+                    output = 'data/northern.csv', strict = True, incorrect_msg = msg2)
+)
 ```
 
 *** =type2: ConsoleExercise
@@ -564,9 +642,15 @@ git commit -m "Added more northern data."
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+commit.+',
-                           fixed=False,
-                           msg='Use `git commit -m "message"` as normal.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "It seems that `data/northern.csv` wasn't changed in the latest commit. Have you used `git commit -m \"Added more northern data\"`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git diff HEAD~ --name-only | grep data/northern.csv',
+                    output = 'data/northern.csv', incorrect_msg=msg2)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -593,9 +677,16 @@ git push origin master
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+push\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git push` with a remote name and a branch name.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "It seems that you still have commits that need to be pushed to the remote. Have you used `git push origin master`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr = 'git log --oneline origin/master..master | wc -l',
+                    output='0', strict=True, incorrect_msg=msg2)
+)
+Ex().success_msg("Success! Head over to the very last exercise of this course!")
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -605,6 +696,7 @@ Ex() >> test_student_typed(r'\s*git\s+push\s+origin\s+master\s*',
 
 Overwriting your own work by accident is bad;
 overwriting someone else's is worse.
+
 To prevent this happening,
 Git does not allow you to push changes to a remote repository
 unless you have merged the contents of the remote repository into your own work.
@@ -630,7 +722,7 @@ repl.run_command('git commit -m "Adding a record"')
 
 *** =instructions1
 
-You have made changes to the `dental` repository.
+You have made and committed changes to the `dental` repository locally.
 Use `git push` to push those changes to the remote repository `origin`.
 
 *** =hint1
@@ -648,9 +740,17 @@ git push origin master
 
 *** =sct1
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+push\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git push` with the remote name and the branch name.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "Have you used `git push origin master` to attempt to push your local changes to the repo?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    # Not sure how to test this robustly, as the command should fail...
+    has_code(r'\s*git\s+push\s+origin\s+master\s*',
+             fixed=False, incorrect_msg=msg2)
+)
+Ex().success_msg("Success! Head over to the very last exercise of this course!")
 ```
 
 *** =type2: ConsoleExercise
@@ -662,7 +762,7 @@ Ex() >> test_student_typed(r'\s*git\s+push\s+origin\s+master\s*',
 
 In order to prevent you overwriting remote work,
 Git has refused to execute your push.
-Use `git pull` to bring your repository up to date with `origin`.
+Use `git pull` to bring your repository up to date with `origin`. It will open up an editor that you can exit with Ctrl+X.
 
 *** =hint2
 
@@ -674,15 +774,20 @@ Use `git pull` with the name of the remote (`origin`) and the name of the branch
 
 *** =solution2
 ```{shell}
-# Run this command *without* '--no-edit':
 git pull --no-edit origin master
 ```
 
 *** =sct2
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+pull.*\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git pull` with the remote name and the branch name.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "If the `git pull` went well, you should have 16 commits in your repo, but you don't. Make sure you use `git pull origin master`. If you want to avoid the editor from opening, you can use the `--no-edit` flag."
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr='git rev-list --all --count',
+                    output= '16', strict=True, incorrect_msg=msg2)
+)
 ```
 
 *** =type3: ConsoleExercise
@@ -710,7 +815,14 @@ git push origin master
 
 *** =sct3
 ```{python}
-Ex() >> test_student_typed(r'\s*git\s+push\s+origin\s+master\s*',
-                           fixed=False,
-                           msg='Use `git push` with the remote name and the branch name.')
+msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
+msg2 = "It seems that you still have commits that need to be pushed to the remote. Have you used `git push origin master`?"
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
+                    output='master', strict=True, incorrect_msg=msg1),
+    has_expr_output(expr = 'git log --oneline origin/master..master | wc -l',
+                    output='0', strict=True, incorrect_msg=msg2)
+)
+Ex().success_msg("Success! Head over to the very last exercise of this course!")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -24,6 +24,10 @@ but most programmers and data analysts try to avoid getting into this situation.
 
 Use a single command to create a new Git repository called `optical` below your home directory.
 
+*** =hint
+
+Call `git init`, passing the name of the repository to be created.
+
 *** =solution
 ```{shell}
 git init optical

--- a/chapter5.md
+++ b/chapter5.md
@@ -241,6 +241,9 @@ When you a clone a repository,
 Git remembers where the original repository was.
 It does this by storing a **remote** in the new repository's configuration.
 A remote is like a browser bookmark with a name and a URL.
+
+If you use an online git repository hosting service like GitHub or Bitbucket, a common task would be that you clone a repository from that site to work locally on your computer. Then the copy on the website is the remote.
+
 If you are in a repository,
 you can list the names of its remotes using `git remote`.
 
@@ -354,6 +357,9 @@ Ex().success_msg("Neat! Now you added a remote to your local git repository.")
 Git keeps track of remote repositories so that you can
 **pull** changes from those repositories
 and **push** changes to them.
+
+Recall that the remote repository is often a repository in an online hosting service like GitHub. A typical workflow is that you pull in your collaborators' work from the remote repository so you have the latest version of everything, do some work yourself, then push your work back to the remote so that your collaborators have access to it.
+
 Pulling changes is straightforward:
 the command `git pull remote branch`
 gets everything in `branch` in the remote repository identified by `remote`
@@ -387,10 +393,7 @@ repl.run_command('cd dental')
 
 *** =instructions1
 
-You are in the `master` branch of the repository `dental`,
-which has a remote called `origin`.
-Pull all of the changes in the `master` branch of that remote repository
-into the `master` branch of your repository.
+You are in the `master` branch of the repository `dental`. Pull the changes from the `master` branch of the remote repository called `origin`.
 
 *** =hint1
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -846,5 +846,5 @@ Ex().multi(
     has_expr_output(expr = 'git log --oneline origin/master..master | wc -l',
                     output='0', strict=True, incorrect_msg=msg2)
 )
-Ex().success_msg("Success! Head over to the very last exercise of this course!")
+Ex().success_msg("Gee-whiz! You've finished the course!")
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -77,7 +77,7 @@ repl.run_command('pwd')
 *** =type1: ConsoleExercise
 *** =key1: 101686c0e7
 
-*** =xp1: 10
+*** =xp1: 50
 
 *** =instructions1
 
@@ -110,7 +110,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: e65f050907
 
-*** =xp2: 10
+*** =xp2: 50
 
 *** =instructions2
 
@@ -202,7 +202,7 @@ repl.run_command('ls')
 *** =type1: ConsoleExercise
 *** =key1: 2b06ff535f
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -317,7 +317,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: a0e2cf2d0f
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -387,7 +387,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: cb79240464
 
-*** =xp1: 10
+*** =xp1: 100
 
 *** =instructions1
 
@@ -448,7 +448,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: f03c277669
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -485,7 +485,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: 301f2bd8a3
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -519,7 +519,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 2cad24ea7a
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 
@@ -586,7 +586,7 @@ repl.run_command('cd dental')
 *** =type1: ConsoleExercise
 *** =key1: 75df26b3a7
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -624,7 +624,7 @@ Ex().multi(
 *** =type2: ConsoleExercise
 *** =key2: eebd73b616
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -659,7 +659,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 037b960128
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 
@@ -721,7 +721,7 @@ repl.run_command('git commit -m "Adding a record"')
 *** =type1: ConsoleExercise
 *** =key1: 2b8815a979
 
-*** =xp1: 10
+*** =xp1: 30
 
 *** =instructions1
 
@@ -759,7 +759,7 @@ Ex().success_msg("Success! Head over to the very last exercise of this course!")
 *** =type2: ConsoleExercise
 *** =key2: 0af344b542
 
-*** =xp2: 10
+*** =xp2: 30
 
 *** =instructions2
 
@@ -796,7 +796,7 @@ Ex().multi(
 *** =type3: ConsoleExercise
 *** =key3: 9ddb421159
 
-*** =xp3: 10
+*** =xp3: 40
 
 *** =instructions3
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -168,22 +168,14 @@ https://github.com/datacamp/project.git
 ```
 
 but for this lesson,
-we will use **filesystem URLs** of the form 
-
-```
-file:///existing/project
-```
-
-The number of slashes at the start is important:
-the first part of the URL is `file://`,
-and then there is a third slash to start the absolute path `/existing/project`.
+we will use a repository on the local file system, so you can just use a path to that directory.
 
 When you clone a repository,
 Git uses the name of the existing repository as the name of the clone's root directory:
 for example,
 
 ```
-git clone file:///existing/project
+git clone /existing/project
 ```
 
 will create a new directory called `project`.
@@ -191,7 +183,7 @@ If you want to call the clone something else,
 add the directory name you want to the command:
 
 ```
-git clone file:///existing/project newprojectname
+git clone /existing/project newprojectname
 ```
 
 *** =pre_exercise_code
@@ -218,7 +210,7 @@ to create a new repository called `dental` inside your home directory
 
 *** =hint1
 
-Remember to count the slashes after `file:` carefully.
+Call `git clone`, passing the absolute path the the existing repository, and the name for the new repository.
 
 *** =sample_code1
 ```{shell}
@@ -226,12 +218,12 @@ Remember to count the slashes after `file:` carefully.
 
 *** =solution1
 ```{shell}
-git clone file:///home/thunk/repo dental
+git clone /home/thunk/repo dental
 ```
 
 *** =sct1
 ```{python}
-msgpatt = "There is no folder %s in %s. Have you used `git clone file:///home/thunk/repo dental` to copy the repository from /home/thunk/repo?"
+msgpatt = "There is no folder %s in %s. Have you used `git clone /home/thunk/repo dental` to copy the repository from /home/thunk/repo?"
 Ex().multi(
     has_cwd('/home/repl'),
     has_dir('/home/repl/dental', incorrect_msg=msgpatt % ('`dental`', '`/home/repl`')),

--- a/chapter5.md
+++ b/chapter5.md
@@ -275,9 +275,9 @@ repl.run_command('cd dental')
 
 *** =sct
 ```{python}
-Ex().has_chosen(2, ['No: there are some remotes.',
+Ex().has_chosen(2, ['No: Look at the output from `git remote`.',
                     'Correct!',
-                    'No: there is just one remote.'])
+                    'No: there is just one remote, but it has several URLs.'])
 ```
 
 <!-- -------------------------------------------------------------------------------- -->
@@ -413,7 +413,7 @@ Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
                     output='master', strict=True, incorrect_msg=msg1),
-    has_expr_output("git log -1 --pretty=%B | grep Reminder", output="Reminder to add references to report.",
+    has_expr_output(expr = "git log -1 --pretty=%B | grep Reminder", output="Reminder to add references to report.", strict=True,
                     incorrect_msg=msg2)
 )
 Ex().success_msg("Well done! This `git pull` went smoothly, but unfortunately that's not always the case. Let's see what can happen if you have unsaved changes when trying to pull in changes.")

--- a/chapter5.md
+++ b/chapter5.md
@@ -476,7 +476,7 @@ Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
                     output='master', strict=True, incorrect_msg=msg1),
-    has_code(r'\s*git\s+pull\s+origin\s+master\s*',
+    has_code(r'\s*git\s+pull\s*',
               fixed=False, incorrect_msg='Use `git pull origin master` to pull in changes.')
 )
 ```

--- a/chapter5.md
+++ b/chapter5.md
@@ -223,7 +223,7 @@ git clone /home/thunk/repo dental
 
 *** =sct1
 ```{python}
-msgpatt = "There is no folder %s in %s. Have you used `git clone /home/thunk/repo dental` to copy the repository from /home/thunk/repo?"
+msgpatt = "There is no folder %s in %s. Have you used `git clone` with the original repository location and the new name?"
 Ex().multi(
     has_cwd('/home/repl'),
     has_dir('/home/repl/dental', incorrect_msg=msgpatt % ('`dental`', '`/home/repl`')),

--- a/chapter5.md
+++ b/chapter5.md
@@ -645,13 +645,33 @@ git commit -m "Added more northern data."
 *** =sct2
 ```{python}
 msg1 = "Make sure you are on the `master` branch (use `git checkout master` to switch to it)."
-msg2 = "It seems that `data/northern.csv` wasn't changed in the latest commit. Have you used `git commit -m \"Added more northern data\"`?"
+msg2 = "It seems that `data/northern.csv` wasn't changed in the latest commit. Have you used `git commit -m \"Added more northern data.\"`?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output(expr='git rev-parse --abbrev-ref HEAD | grep master',
                     output='master', strict=True, incorrect_msg=msg1),
     has_expr_output(expr='git diff HEAD~ --name-only | grep data/northern.csv',
                     output = 'data/northern.csv', incorrect_msg=msg2)
+)
+not_committed_msg = "It seems that the staged changes to `data/northern.csv` weren't committed. Have you used `git commit` with `-m \"Added more northern data.\"`?"
+bad_message_msg = 'It seems the commit message was incorrect. You can amend it with `git commit --amend -m "new message"`.'
+Ex().multi(
+    has_cwd('/home/repl/dental'),
+    check_or(
+        has_expr_output(
+            expr='git diff HEAD~ --name-only | grep data/northern.csv',
+            output = 'data/northern.csv',
+            strict=True,
+            incorrect_msg=not_committed_msg
+        ),
+        has_code(r'\s*git\s+commit', incorrect_msg = not_committed_msg)            
+    ),
+    has_expr_output(
+        expr='git log -1 | grep --only-matching "Added more northern data"',
+        output = 'Added more northern data',
+        strict=True,
+        incorrect_msg=bad_message_msg
+    )
 )
 ```
 

--- a/chapter5.md
+++ b/chapter5.md
@@ -271,7 +271,7 @@ Run `git remote` in the `dental` repository.
 ```{shell}
 repl = connect('bash')
 repl.run_command('rm -rf dental')
-repl.run_command('git clone file:///home/thunk/repo dental')
+repl.run_command('git clone /home/thunk/repo dental')
 repl.run_command('clear')
 repl.run_command('cd dental')
 ```
@@ -321,7 +321,7 @@ repl.run_command('cd dental')
 *** =instructions1
 
 You are in the `dental` repository.
-Add `file:///home/thunk/repo` as a remote called `thunk` to it.
+Add `/home/thunk/repo` as a remote called `thunk` to it.
 
 *** =hint1
 
@@ -333,18 +333,26 @@ Be sure to count the slashes properly in the remote URL.
 
 *** =solution1
 ```{shell}
-git remote add thunk file:///home/thunk/repo
+git remote add thunk /home/thunk/repo
 ```
 
 *** =sct1
 ```{python}
 msg1="The system couldn't find a remote with the name `thunk`. Have you used `git remote add thunk <path_to_remote>`?"
-msg2="Are you sure the path of the thunk remote is correct? Have you used `git remote add thunk file:///home/thunk/repo`?"
+msg2="Are you sure the path of the thunk remote is correct? Have you used `git remote add thunk /home/thunk/repo`?"
 Ex().multi(
     has_cwd('/home/repl/dental'),
     has_expr_output('git remote', output='thunk', strict=True, incorrect_msg=msg1),
-    has_expr_output('git remote get-url thunk',
-                    output='file:///home/thunk/repo', strict=True, incorrect_msg=msg2)
+    check_or(
+        has_expr_output(
+            'git remote get-url thunk',
+             output='/home/thunk/repo', strict=True, incorrect_msg=msg2
+        ),
+        has_expr_output(
+            'git remote get-url thunk',
+             output='file:///home/thunk/repo', strict=True, incorrect_msg=msg2
+        )
+    )
 )
 Ex().success_msg("Neat! Now you added a remote to your local git repository.")
 ```
@@ -380,7 +388,7 @@ and merge them into your `quarterly-report` branch.
 ```{python}
 repl = connect('bash')
 repl.run_command('rm -rf dental')
-repl.run_command('git clone file:///home/thunk/repo dental')
+repl.run_command('git clone /home/thunk/repo dental')
 repl.run_command('git -C dental reset --hard HEAD~2')
 repl.run_command('clear')
 repl.run_command('cd dental')
@@ -437,7 +445,7 @@ and then try to pull again.
 ```{python}
 repl = connect('bash')
 repl.run_command('rm -rf dental')
-repl.run_command('git clone file:///home/thunk/repo dental')
+repl.run_command('git clone /home/thunk/repo dental')
 repl.run_command('git -C dental reset --hard HEAD~1')
 repl.run_command('echo "One final thing..." >> dental/report.txt')
 repl.run_command('clear')
@@ -575,7 +583,7 @@ it's almost always better to use the same names for branches across repositories
 ```{python}
 repl = connect('bash')
 repl.run_command('rm -rf dental')
-repl.run_command('git clone file:///home/thunk/repo dental')
+repl.run_command('git clone /home/thunk/repo dental')
 with open('dental/data/northern.csv', 'a') as writer:
     writer.write('2017-11-01,bicuspid\n')
 repl.run_command('clear')
@@ -727,7 +735,7 @@ unless you have merged the contents of the remote repository into your own work.
 ```{python}
 repl = connect('bash')
 repl.run_command('rm -rf dental')
-repl.run_command('git clone file:///home/thunk/repo dental')
+repl.run_command('git clone /home/thunk/repo dental')
 repl.run_command('git -C dental reset --hard HEAD~1')
 with open('dental/data/northern.csv', 'a') as writer:
     writer.write('2017-11-01,bicuspid\n')

--- a/requirements.sh
+++ b/requirements.sh
@@ -6,9 +6,6 @@ HOME_COPY=/.course_home
 USER_GROUP=repl:repl
 COURSE_ID=course_5355
 ARCHIVE=setup.zip
-PYTHON=python3
-PIP=pip3
-SHELLWHAT_EXT=git+https://github.com/datacamp/shellwhat_ext.git@v0.2.0
 
 # Report start.
 echo ''
@@ -27,12 +24,10 @@ apt-get update
 apt-get -y install nano
 apt-get -y install unzip
 
-# Python package installation.
-${PIP} install gitpython
-${PIP} install ${SHELLWHAT_EXT} --no-deps
-${PYTHON} -c "import sys; print('sys.version:', sys.version)"
-${PYTHON} -c "import git; print('gitpython version:', git.__version__)"
-${PYTHON} -c "import shellwhat_ext; print('shellwhat_ext version:', shellwhat_ext.__version__)"
+## Install dev version of protowhat and shellwhat
+pip3 install jinja2==2.10
+pip3 install git+https://github.com/datacamp/protowhat.git@fs/refactor2
+pip3 install git+https://github.com/datacamp/shellwhat.git@fs/refactor --no-dependencies
 
 # Echo shell commands as they are executed.
 set -x

--- a/requirements.sh
+++ b/requirements.sh
@@ -26,8 +26,8 @@ apt-get -y install unzip
 
 ## Install dev version of protowhat and shellwhat
 pip3 install jinja2==2.10
-pip3 install git+https://github.com/datacamp/protowhat.git@fs/refactor2
-pip3 install git+https://github.com/datacamp/shellwhat.git@fs/refactor --no-dependencies
+pip3 install protowhat==1.1.1
+pip3 install shellwhat==1.0.0 --no-dependencies
 
 # Echo shell commands as they are executed.
 set -x

--- a/rules.yml
+++ b/rules.yml
@@ -1,0 +1,74 @@
+rules:
+    course_pct_ex_assignment_lte_reco:
+        min: 0
+        max: 1
+    course_pct_ex_code_sample_lte_reco:
+        min: 0
+        max: 1
+    course_pct_ex_code_solution_lte_reco:
+        min: 0
+        max: 1
+    mce_num_chars_assignment:
+        min: 0
+        max: 2000
+    mce_num_chars_options:
+        min: 0
+        max: 400
+    mce_num_items_options:
+        min: 0
+        max: 10
+    normal_exercise_num_chars_instructions:
+        min: 0
+        max: 100000
+    normal_exercise_num_items_instructions:
+        min: 0
+        max: 100000
+    normal_exercise_num_chars_assignment:
+        min: 0
+        max: 100000
+    normal_exercise_num_subitems_instructions:
+        min: 0
+        max: 100000
+    normal_exercise_num_chars_hints:
+        min: 0
+        max: 10000
+    normal_exercise_num_items_hints:
+        min: 0
+        max: 10000
+    normal_exercise_num_lines_code_sample:
+        min: 0
+        max: 10000
+    normal_exercise_num_lines_code_solution:
+        min: 0
+        max: 10000
+    normal_exercise_has_sct:
+        min: 0
+        max: 10000
+    normal_exercise_has_sct_success_msg:
+        min: 0
+        max: 10000
+    course_num_chapters:
+        min: 0
+        max: 10000
+    course_num_exercises:
+        min: 0
+        max: 10000
+    chapter_num_exercises_chapter_1:
+        min: 0
+        max: 10000
+    chapter_num_exercises_chapter_n:
+        min: 0
+        max: 10000
+    course_pct_ex_instructions_lte_reco:
+        min: 0
+    course_pct_ex_assignment_lte_reco:
+        min: 0.0
+    course_pct_ex_hints_lte_reco:
+        min: 0.0
+    course_pct_ex_code_sample_lte_reco:
+        min: 0.0
+    course_pct_ex_code_solution_lte_reco:
+        min: 0.0
+    all_exercises_num_chars_title:
+        min: 1
+        max: 10000

--- a/rules.yml
+++ b/rules.yml
@@ -17,58 +17,6 @@ rules:
     mce_num_items_options:
         min: 0
         max: 10
-    normal_exercise_num_chars_instructions:
-        min: 0
-        max: 100000
-    normal_exercise_num_items_instructions:
-        min: 0
-        max: 100000
-    normal_exercise_num_chars_assignment:
-        min: 0
-        max: 100000
-    normal_exercise_num_subitems_instructions:
-        min: 0
-        max: 100000
-    normal_exercise_num_chars_hints:
-        min: 0
-        max: 10000
-    normal_exercise_num_items_hints:
-        min: 0
-        max: 10000
-    normal_exercise_num_lines_code_sample:
-        min: 0
-        max: 10000
-    normal_exercise_num_lines_code_solution:
-        min: 0
-        max: 10000
-    normal_exercise_has_sct:
-        min: 0
-        max: 10000
-    normal_exercise_has_sct_success_msg:
-        min: 0
-        max: 10000
-    course_num_chapters:
-        min: 0
-        max: 10000
-    course_num_exercises:
-        min: 0
-        max: 10000
-    chapter_num_exercises_chapter_1:
-        min: 0
-        max: 10000
-    chapter_num_exercises_chapter_n:
-        min: 0
-        max: 10000
-    course_pct_ex_instructions_lte_reco:
-        min: 0
-    course_pct_ex_assignment_lte_reco:
-        min: 0.0
-    course_pct_ex_hints_lte_reco:
-        min: 0.0
-    course_pct_ex_code_sample_lte_reco:
-        min: 0.0
-    course_pct_ex_code_solution_lte_reco:
-        min: 0.0
     all_exercises_num_chars_title:
         min: 1
-        max: 10000
+        max: 100


### PR DESCRIPTION
Major refactor of SCTs …

- Bake in new version of shellwhat (and protowhat)
- Rewrite + (hopefully significantly) improve all SCTs accordingly.
   + Look at side effects of commands whenever possible to allow for more flexibility.
- Minor improvements to exercises and instructions here and there.

Closes #44 
Closes #30 
Closes #19 
Closes #18 
Closes #24 

As you can see, I haven't changed too much about assignment text, instructions and those kinds of things, even though I think the course could use some love. Overall:

- Way too little information about how the exercises are set up!
- There is no narrative throughout the exercises. The setup is always different. This is confusing for students.
- The tone of speech is dry, and explanations are very minimalistic
- Instructions or the 'story telling' could be more interesting.
- There are a bunch of BulletConsoleExercise's in there with one bullet. If you switch this to simple ConsoleExercise, you mess up people's XP though, so I didnt' do it. (it goes from a parent exercise with a subexercise to a single exercise). I would not change this without consulting with the main/learn engineering teams.

Let me know if there are any questions.